### PR TITLE
Modernize ForgeGradle config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,35 +1,17 @@
-
-// For those who want the bleeding edge
-buildscript {
-    repositories {
-        jcenter()
-        maven {
-            name = "forge"
-            url = "http://files.minecraftforge.net/maven"
-        }
-    }
-    dependencies {
-        classpath 'net.minecraftforge.gradle:ForgeGradle:2.1-SNAPSHOT'
-    }
-}
-apply plugin: 'net.minecraftforge.gradle.forge'
-
-/*
-// for people who want stable - not yet functional for MC 1.8.8 - we require the forgegradle 2.1 snapshot
 plugins {
-    id "net.minecraftforge.gradle.forge" version "2.0.2"
+    id "net.minecraftforge.gradle" version "X.Y.Z"
 }
-*/
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+java {
+    toolchain.languageVersion = JavaLanguageVersion.of(17)
+}
 
 version = "1.8.9-7.0.0-A2.3"
 group= "org.millenaire.millenaire" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "millenaire"
 
 minecraft {
-    version = "1.8.9-11.15.1.1761"
+    version = "<aktuelle_mc_version>-<forge_version>"
     runDir = "../run"
     
     // the mappings can be changed at any time, and must be in the following format.
@@ -37,7 +19,7 @@ minecraft {
     // stable_#            stables are built at the discretion of the MCP team.
     // Use non-default mappings at your own risk. they may not allways work.
     // simply re-run your setup task after changing the mappings to update your workspace.
-    mappings = "stable_20"
+    mappings channel: 'official', version: '<aktuelle_mc_version>'
     // makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
 }
 


### PR DESCRIPTION
## Summary
- use new `plugins` DSL for ForgeGradle
- configure Minecraft version and mappings with placeholders
- upgrade to Java toolchain 17

## Testing
- `bash gradlew --version` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6870f38fa0948330a35e94760ca92d43