### PR TITLE
Switch to SimpleChannel networking

### DIFF
--- a/src/main/java/org/millenaire/MillCulture.java
+++ b/src/main/java/org/millenaire/MillCulture.java
@@ -17,7 +17,7 @@ import org.millenaire.util.JsonHelper.VillageTypes;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
-import net.minecraft.server.MinecraftServer;
+import net.minecraftforge.fml.server.ServerLifecycleHooks;
 
 public class MillCulture 
 {
@@ -134,7 +134,7 @@ public class MillCulture
 	public void exportVillages(JsonHelper.VillageTypes villagetypes) {
 		Gson gson = new GsonBuilder().setPrettyPrinting().create();
 		//System.out.println(gson.toJson(villagetypes));
-		File f = new File(MinecraftServer.getServer().getDataDirectory().getAbsolutePath() + File.separator + "millenaire" + File.separator + "exports" + File.separator);
+                File f = new File(ServerLifecycleHooks.getCurrentServer().getDataDirectory().getAbsolutePath() + File.separator + "millenaire" + File.separator + "exports" + File.separator);
 		File f1 = new File(f, "villages.json");
 		try {
 			f.mkdirs();

--- a/src/main/java/org/millenaire/Millenaire.java
+++ b/src/main/java/org/millenaire/Millenaire.java
@@ -27,8 +27,8 @@ import net.minecraftforge.fml.common.Mod.Instance;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.event.server.FMLServerStartingEvent;
-import net.minecraftforge.fml.common.network.NetworkRegistry;
-import net.minecraftforge.fml.common.network.simpleimpl.SimpleNetworkWrapper;
+import net.minecraftforge.fml.network.NetworkRegistry;
+import net.minecraftforge.fml.network.simple.SimpleChannel;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 import net.minecraftforge.fml.relauncher.Side;
 
@@ -47,7 +47,7 @@ public class Millenaire
 	
         @Instance
         public static Millenaire instance = new Millenaire();
-        public static SimpleNetworkWrapper simpleNetworkWrapper;
+        public static SimpleChannel channel;
 
         public Millenaire() {
                 FMLJavaModLoadingContext.get().getModEventBus().addListener(this::setup);
@@ -83,11 +83,12 @@ public class Millenaire
 
                 MillAchievement.preinitialize();
 
-                simpleNetworkWrapper = NetworkRegistry.INSTANCE.newSimpleChannel("MillChannel");
-                simpleNetworkWrapper.registerMessage(MillPacket.PacketHandlerOnServer.class, MillPacket.class, 0, Side.SERVER);
-                simpleNetworkWrapper.registerMessage(PacketImportBuilding.Handler.class, PacketImportBuilding.class, 1, Side.SERVER);
-                simpleNetworkWrapper.registerMessage(PacketSayTranslatedMessage.Handler.class, PacketSayTranslatedMessage.class, 2, Side.CLIENT);
-                simpleNetworkWrapper.registerMessage(PacketExportBuilding.Handler.class, PacketExportBuilding.class, 3, Side.SERVER);
+                channel = NetworkRegistry.newSimpleChannel(new ResourceLocation(MODID, "main"), () -> "1", s -> true, s -> true);
+                int id = 0;
+                channel.registerMessage(id++, MillPacket.class, MillPacket::encode, MillPacket::decode, MillPacket::handle);
+                channel.registerMessage(id++, PacketImportBuilding.class, PacketImportBuilding::encode, PacketImportBuilding::decode, PacketImportBuilding::handle);
+                channel.registerMessage(id++, PacketSayTranslatedMessage.class, PacketSayTranslatedMessage::encode, PacketSayTranslatedMessage::decode, PacketSayTranslatedMessage::handle);
+                channel.registerMessage(id++, PacketExportBuilding.class, PacketExportBuilding::encode, PacketExportBuilding::decode, PacketExportBuilding::handle);
 
                 NetworkRegistry.INSTANCE.registerGuiHandler(instance, new MillGuiHandler());
                 GameRegistry.registerWorldGenerator(new VillageGenerator(), 1000);

--- a/src/main/java/org/millenaire/building/PlanIO.java
+++ b/src/main/java/org/millenaire/building/PlanIO.java
@@ -23,7 +23,7 @@ import net.minecraft.nbt.CompressedStreamTools;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.nbt.NBTTagString;
-import net.minecraft.server.MinecraftServer;
+import net.minecraftforge.fml.server.ServerLifecycleHooks;
 import net.minecraft.tileentity.TileEntitySign;
 import net.minecraft.util.BlockPos;
 import net.minecraft.util.EnumFacing;
@@ -50,7 +50,7 @@ public class PlanIO {
 
 			if(buildingLevel < 0) {
 				PacketSayTranslatedMessage packet = new PacketSayTranslatedMessage("message.error.exporting.level0");
-				Millenaire.simpleNetworkWrapper.sendTo(packet, (EntityPlayerMP)player);
+                                Millenaire.channel.sendTo(packet, (EntityPlayerMP)player);
 			}
 
 			int startLevel = -1;
@@ -61,7 +61,7 @@ public class PlanIO {
 
 			if(buildingName == null || buildingName.length() == 0) {
 				PacketSayTranslatedMessage packet = new PacketSayTranslatedMessage("message.error.exporting.noname");
-				Millenaire.simpleNetworkWrapper.sendTo(packet, (EntityPlayerMP)player);
+                                Millenaire.channel.sendTo(packet, (EntityPlayerMP)player);
 				throw new Exception("exporting.noname");
 			}
 			boolean foundEnd = false;
@@ -77,7 +77,7 @@ public class PlanIO {
 			}
 			if(!foundEnd) {
 				PacketSayTranslatedMessage packet = new PacketSayTranslatedMessage("message.error.exporting.xaxis");
-				Millenaire.simpleNetworkWrapper.sendTo(packet, (EntityPlayerMP)player);
+                                Millenaire.channel.sendTo(packet, (EntityPlayerMP)player);
 				throw new Exception("exporting.xaxis");
 			}
 			foundEnd = false;
@@ -93,7 +93,7 @@ public class PlanIO {
 			}
 			if(!foundEnd) {
 				PacketSayTranslatedMessage packet = new PacketSayTranslatedMessage("message.error.exporting.zaxis");
-				Millenaire.simpleNetworkWrapper.sendTo(packet, (EntityPlayerMP)player);
+                                Millenaire.channel.sendTo(packet, (EntityPlayerMP)player);
 				throw new Exception("Ahhh!");
 			}
 			final int width = xEnd - startPoint.getX() - 1;
@@ -154,8 +154,8 @@ public class PlanIO {
 		}
 		catch(Exception e) {
 			e.printStackTrace();
-			PacketSayTranslatedMessage packet2 = new PacketSayTranslatedMessage("message.notcompleted");
-			Millenaire.simpleNetworkWrapper.sendTo(packet2, (EntityPlayerMP)player);
+                        PacketSayTranslatedMessage packet2 = new PacketSayTranslatedMessage("message.notcompleted");
+                        Millenaire.channel.sendTo(packet2, (EntityPlayerMP)player);
 		}
 	}
 
@@ -171,20 +171,20 @@ public class PlanIO {
 
 			if(name == null || name.length() == 0) {
 				PacketSayTranslatedMessage message = new PacketSayTranslatedMessage("message.error.exporting.noname");
-				Millenaire.simpleNetworkWrapper.sendTo(message, (EntityPlayerMP)player);
+                                Millenaire.channel.sendTo(message, (EntityPlayerMP)player);
 				PacketSayTranslatedMessage packet = new PacketSayTranslatedMessage("message.notcompleted");
-				Millenaire.simpleNetworkWrapper.sendTo(packet, (EntityPlayerMP)player);
+                                Millenaire.channel.sendTo(packet, (EntityPlayerMP)player);
 				return;
 			}
 
-			World world = MinecraftServer.getServer().getEntityWorld();
+                        World world = ServerLifecycleHooks.getCurrentServer().getEntityWorld();
 
 			File schem = getBuildingFile(name);
 			if(!schem.exists()) {
 				PacketSayTranslatedMessage message = new PacketSayTranslatedMessage("message.error.importing.nofile");
-				Millenaire.simpleNetworkWrapper.sendTo(message, (EntityPlayerMP)player);
+                                Millenaire.channel.sendTo(message, (EntityPlayerMP)player);
 				PacketSayTranslatedMessage packet = new PacketSayTranslatedMessage("message.notcompleted");
-				Millenaire.simpleNetworkWrapper.sendTo(packet, (EntityPlayerMP)player);
+                                Millenaire.channel.sendTo(packet, (EntityPlayerMP)player);
 				return;
 			}
 			FileInputStream fis = new FileInputStream(schem);
@@ -202,7 +202,7 @@ public class PlanIO {
 		} catch (IOException e) {
 			e.printStackTrace();
 			PacketSayTranslatedMessage message = new PacketSayTranslatedMessage("message.error.unknown");
-			Millenaire.simpleNetworkWrapper.sendTo(message, (EntityPlayerMP)player);
+                        Millenaire.channel.sendTo(message, (EntityPlayerMP)player);
 		}
 	}
 	
@@ -304,8 +304,8 @@ public class PlanIO {
 		}
 	}
 
-	private static File getBuildingFile(final String name) {
-		File f = new File(MinecraftServer.getServer().getDataDirectory().getAbsolutePath() + File.separator + "millenaire" + File.separator + "exports" + File.separator);
+        private static File getBuildingFile(final String name) {
+                File f = new File(ServerLifecycleHooks.getCurrentServer().getDataDirectory().getAbsolutePath() + File.separator + "millenaire" + File.separator + "exports" + File.separator);
 		if(!f.exists())
 		{
 			f.mkdirs();
@@ -349,7 +349,7 @@ public class PlanIO {
 
 		if(!valid(width, height, length, depth, tag)) {
 			PacketSayTranslatedMessage packet = new PacketSayTranslatedMessage("message.error.exporting.dimensions");
-			Millenaire.simpleNetworkWrapper.sendTo(packet, (EntityPlayerMP)player);
+                        Millenaire.channel.sendTo(packet, (EntityPlayerMP)player);
 			throw new Exception("Ahhh!");
 		}
 
@@ -398,7 +398,7 @@ public class PlanIO {
 			e.printStackTrace();
 		}
 		PacketSayTranslatedMessage packet = new PacketSayTranslatedMessage("message.completed");
-		Millenaire.simpleNetworkWrapper.sendTo(packet, (EntityPlayerMP)player);
+                Millenaire.channel.sendTo(packet, (EntityPlayerMP)player);
 		return f1;
 	}
 }

--- a/src/main/java/org/millenaire/gui/GuiOptions.java
+++ b/src/main/java/org/millenaire/gui/GuiOptions.java
@@ -47,15 +47,15 @@ public class GuiOptions extends GuiScreen
 		{
 			if(eventID == 2)
 			{
-				Millenaire.simpleNetworkWrapper.sendToServer(new MillPacket(2));
+                                Millenaire.channel.sendToServer(new MillPacket(2));
 			}
 			if(eventID == 3)
 			{
-				Millenaire.simpleNetworkWrapper.sendToServer(new MillPacket(3));
+                                Millenaire.channel.sendToServer(new MillPacket(3));
 			}
 			if(eventID == 4)
 			{
-				Millenaire.simpleNetworkWrapper.sendToServer(new MillPacket(4));
+                                Millenaire.channel.sendToServer(new MillPacket(4));
 			}
 			this.mc.displayGuiScreen(null);
 	        if (this.mc.currentScreen == null)

--- a/src/main/java/org/millenaire/items/ItemMillWand.java
+++ b/src/main/java/org/millenaire/items/ItemMillWand.java
@@ -40,12 +40,12 @@ public class ItemMillWand extends Item
 	{
 		if(worldIn.getBlockState(pos).getBlock() == Blocks.standing_sign && worldIn.isRemote && this == MillItems.wandNegation) {
 			PacketExportBuilding packet = new PacketExportBuilding(pos);
-			Millenaire.simpleNetworkWrapper.sendToServer(packet);
+                        Millenaire.channel.sendToServer(packet);
 			return true;
 		}
 		else if(worldIn.getBlockState(pos).getBlock() == Blocks.standing_sign && worldIn.isRemote && this == MillItems.wandSummoning) {
 			PacketImportBuilding packet =  new PacketImportBuilding(pos);
-			Millenaire.simpleNetworkWrapper.sendToServer(packet);
+                        Millenaire.channel.sendToServer(packet);
 			return true;
 		}
 		return false;
@@ -78,7 +78,7 @@ public class ItemMillWand extends Item
 				if(!worldIn.isRemote)
 				{	
 					System.out.println("Gold Creation");
-					Millenaire.simpleNetworkWrapper.sendTo(new PacketSayTranslatedMessage("message.notimplemented"), (EntityPlayerMP)playerIn);
+                                        Millenaire.channel.sendTo(new PacketSayTranslatedMessage("message.notimplemented"), (EntityPlayerMP)playerIn);
 					//Gui confirming action and desired village, then villageStone block is made and villageType assigned
 				}
 			}
@@ -94,7 +94,7 @@ public class ItemMillWand extends Item
 
 				if(!worldIn.isRemote)
 				{
-					Millenaire.simpleNetworkWrapper.sendTo(new PacketSayTranslatedMessage("message.notimplemented"), (EntityPlayerMP)playerIn);
+                                        Millenaire.channel.sendTo(new PacketSayTranslatedMessage("message.notimplemented"), (EntityPlayerMP)playerIn);
 //					playerIn.openGui(Millenaire.instance, 4, worldIn, playerIn.getPosition().getX(), playerIn.getPosition().getY(), playerIn.getPosition().getZ());
 				} 
 

--- a/src/main/java/org/millenaire/networking/PacketExportBuilding.java
+++ b/src/main/java/org/millenaire/networking/PacketExportBuilding.java
@@ -3,7 +3,10 @@ package org.millenaire.networking;
 import org.millenaire.building.PlanIO;
 
 import io.netty.buffer.ByteBuf;
-import net.minecraft.server.MinecraftServer;
+import net.minecraft.network.PacketBuffer;
+import net.minecraftforge.fml.network.NetworkEvent;
+import java.util.function.Supplier;
+import net.minecraftforge.fml.server.ServerLifecycleHooks;
 import net.minecraft.util.BlockPos;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;
@@ -29,17 +32,32 @@ public class PacketExportBuilding implements IMessage {
 	}
 
 	@Override
-	public void toBytes(ByteBuf buf) {
-		buf.writeInt(pos.getX());
-		buf.writeInt(pos.getY());
-		buf.writeInt(pos.getZ());
-	}
+        public void toBytes(ByteBuf buf) {
+                buf.writeInt(pos.getX());
+                buf.writeInt(pos.getY());
+                buf.writeInt(pos.getZ());
+        }
+
+        public static void encode(PacketExportBuilding msg, PacketBuffer buf) {
+                buf.writeInt(msg.pos.getX());
+                buf.writeInt(msg.pos.getY());
+                buf.writeInt(msg.pos.getZ());
+        }
+
+        public static PacketExportBuilding decode(PacketBuffer buf) {
+                return new PacketExportBuilding(new BlockPos(buf.readInt(), buf.readInt(), buf.readInt()));
+        }
+
+        public static void handle(PacketExportBuilding msg, Supplier<NetworkEvent.Context> ctx) {
+                ctx.get().enqueueWork(() -> PlanIO.exportBuilding(ctx.get().getSender(), msg.pos));
+                ctx.get().setPacketHandled(true);
+        }
 
 	public static class Handler implements IMessageHandler<PacketExportBuilding, IMessage> {
 
 		@Override
 		public IMessage onMessage(PacketExportBuilding message, MessageContext ctx) {
-			MinecraftServer.getServer().addScheduledTask(() -> handle(message, ctx));
+                        ServerLifecycleHooks.getCurrentServer().addScheduledTask(() -> handle(message, ctx));
 			return null;
 		}
 		

--- a/src/main/java/org/millenaire/networking/PacketImportBuilding.java
+++ b/src/main/java/org/millenaire/networking/PacketImportBuilding.java
@@ -3,7 +3,10 @@ package org.millenaire.networking;
 import org.millenaire.building.PlanIO;
 
 import io.netty.buffer.ByteBuf;
-import net.minecraft.server.MinecraftServer;
+import net.minecraft.network.PacketBuffer;
+import net.minecraftforge.fml.network.NetworkEvent;
+import java.util.function.Supplier;
+import net.minecraftforge.fml.server.ServerLifecycleHooks;
 import net.minecraft.util.BlockPos;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;
@@ -29,17 +32,32 @@ public class PacketImportBuilding implements IMessage {
 	}
 
 	@Override
-	public void toBytes(ByteBuf buf) {
-		buf.writeInt(pos.getX());
-		buf.writeInt(pos.getY());
-		buf.writeInt(pos.getZ());
-	}
+        public void toBytes(ByteBuf buf) {
+                buf.writeInt(pos.getX());
+                buf.writeInt(pos.getY());
+                buf.writeInt(pos.getZ());
+        }
+
+        public static void encode(PacketImportBuilding msg, PacketBuffer buf) {
+                buf.writeInt(msg.pos.getX());
+                buf.writeInt(msg.pos.getY());
+                buf.writeInt(msg.pos.getZ());
+        }
+
+        public static PacketImportBuilding decode(PacketBuffer buf) {
+                return new PacketImportBuilding(new BlockPos(buf.readInt(), buf.readInt(), buf.readInt()));
+        }
+
+        public static void handle(PacketImportBuilding msg, Supplier<NetworkEvent.Context> ctx) {
+                ctx.get().enqueueWork(() -> PlanIO.importBuilding(ctx.get().getSender(), msg.pos));
+                ctx.get().setPacketHandled(true);
+        }
 
 	public static class Handler implements IMessageHandler<PacketImportBuilding, IMessage> {
 
 		@Override
 		public IMessage onMessage(PacketImportBuilding message, MessageContext ctx) {
-			MinecraftServer.getServer().addScheduledTask(() -> handle(message, ctx));
+                        ServerLifecycleHooks.getCurrentServer().addScheduledTask(() -> handle(message, ctx));
 			return null;
 		}
 		


### PR DESCRIPTION
## Summary
- use `SimpleChannel` instead of the deprecated `SimpleNetworkWrapper`
- register packets through the new channel
- retrieve the server via `ServerLifecycleHooks.getCurrentServer()`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_687103eb32088330ad506e82ed1ece3c