### PR TITLE
Switch dataWatcher to EntityDataManager and add player capability

### DIFF
--- a/src/main/java/org/millenaire/Millenaire.java
+++ b/src/main/java/org/millenaire/Millenaire.java
@@ -13,6 +13,8 @@ import org.millenaire.networking.MillPacket;
 import org.millenaire.networking.PacketExportBuilding;
 import org.millenaire.networking.PacketImportBuilding;
 import org.millenaire.networking.PacketSayTranslatedMessage;
+import org.millenaire.capability.PlayerCropProvider;
+import org.millenaire.capability.CapabilityEvents;
 
 import net.minecraft.block.Block;
 import net.minecraft.creativetab.CreativeTabs;
@@ -68,6 +70,8 @@ public class Millenaire
         private void setup(final FMLCommonSetupEvent event)
         {
                 MillConfig.preinitialize();
+                PlayerCropProvider.register();
+                new CapabilityEvents();
                 MinecraftForge.EVENT_BUS.register(new RaidEvent.RaidEventHandler());
 
                 setForbiddenBlocks();

--- a/src/main/java/org/millenaire/PlayerTracker.java
+++ b/src/main/java/org/millenaire/PlayerTracker.java
@@ -1,83 +1,19 @@
 package org.millenaire;
 
-import java.util.HashMap;
-import java.util.Map;
+import org.millenaire.capability.IPlayerCropData;
 
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.item.Item;
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.world.World;
-import net.minecraftforge.common.IExtendedEntityProperties;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.CapabilityInject;
 
-public class PlayerTracker implements IExtendedEntityProperties
-{
-	private final static String IDENTIFIER = "Millenaire.PlayerInfo";
+public final class PlayerTracker {
 
-	private final EntityPlayer player;
-	
-	private Map<Item, Boolean> playerCropKnowledge = new HashMap<>();
+    @CapabilityInject(IPlayerCropData.class)
+    public static final Capability<IPlayerCropData> CROP_CAPABILITY = null;
 
-	private PlayerTracker(EntityPlayer player) { this.player = player; }
+    private PlayerTracker() {}
 
-	/**
-	 * Used to register these extended properties for the player during EntityConstructing event
-	 * This method is for convenience only; it will make your code look nicer
-	 */
-	public static  void register(EntityPlayer player)
-	{
-		player.registerExtendedProperties(PlayerTracker.IDENTIFIER, new PlayerTracker(player));
-	}
-
-	/**
-	 * Returns ExtendedPlayer properties for player
-	 * This method is for convenience only; it will make your code look nicer
-	 */
-	public static PlayerTracker get(EntityPlayer player)
-	{
-		return (PlayerTracker) player.getExtendedProperties(IDENTIFIER);
-	}
-
-	@Override
-	public void saveNBTData(NBTTagCompound compound)
-	{
-		NBTTagCompound properties = new NBTTagCompound();
-		NBTTagCompound cropKnowledge = new NBTTagCompound();
-
-		for(Item i : playerCropKnowledge.keySet()) {
-			cropKnowledge.setBoolean(Item.itemRegistry.getNameForObject(i).toString(), playerCropKnowledge.get(i));
-		}
-
-		properties.setTag("cropKnowledge", cropKnowledge);
-		compound.setTag(IDENTIFIER, properties);
-	}
-
-	@Override
-	public void loadNBTData(NBTTagCompound compound)
-	{
-		NBTTagCompound properties = (NBTTagCompound) compound.getTag(IDENTIFIER);
-		NBTTagCompound cropKnowledge = properties.getCompoundTag("cropKnowledge");
-		
-		for(String s : cropKnowledge.getKeySet()) {
-			Item i = Item.getByNameOrId(s);
-			Boolean canPlant = cropKnowledge.getBoolean(s);
-			playerCropKnowledge.put(i, canPlant);
-			System.out.println(i + " " + canPlant);
-		}
-	}
-
-	@Override
-	public void init(Entity entity, World world)
-	{
-	}
-	
-	public void setCanUseCrop(Item cropIn, boolean canUse) { playerCropKnowledge.put(cropIn, canUse); }
-
-	public boolean canPlayerUseCrop(Item cropIn) {
-		if(playerCropKnowledge.containsKey(cropIn)) {
-			return playerCropKnowledge.get(cropIn);
-		}
-
-        return false;
-	}
+    public static IPlayerCropData get(EntityPlayer player) {
+        return player.getCapability(CROP_CAPABILITY, null);
+    }
 }

--- a/src/main/java/org/millenaire/capability/CapabilityEvents.java
+++ b/src/main/java/org/millenaire/capability/CapabilityEvents.java
@@ -1,0 +1,24 @@
+package org.millenaire.capability;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.AttachCapabilitiesEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+
+public class CapabilityEvents {
+
+    public static final ResourceLocation PLAYER_CROP_DATA = new ResourceLocation("millenaire", "player_crop_data");
+
+    public CapabilityEvents() {
+        MinecraftForge.EVENT_BUS.register(this);
+    }
+
+    @SubscribeEvent
+    public void onAttachCapabilities(AttachCapabilitiesEvent<Entity> event) {
+        if (event.getObject() instanceof EntityPlayer) {
+            event.addCapability(PLAYER_CROP_DATA, new PlayerCropProvider());
+        }
+    }
+}

--- a/src/main/java/org/millenaire/capability/IPlayerCropData.java
+++ b/src/main/java/org/millenaire/capability/IPlayerCropData.java
@@ -1,0 +1,11 @@
+package org.millenaire.capability;
+
+import net.minecraft.item.Item;
+import net.minecraft.nbt.NBTTagCompound;
+
+public interface IPlayerCropData {
+    void setCanUseCrop(Item crop, boolean canUse);
+    boolean canPlayerUseCrop(Item crop);
+    NBTTagCompound writeNBT();
+    void readNBT(NBTTagCompound nbt);
+}

--- a/src/main/java/org/millenaire/capability/PlayerCropData.java
+++ b/src/main/java/org/millenaire/capability/PlayerCropData.java
@@ -1,0 +1,41 @@
+package org.millenaire.capability;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import net.minecraft.item.Item;
+import net.minecraft.nbt.NBTTagCompound;
+
+public class PlayerCropData implements IPlayerCropData {
+    private Map<Item, Boolean> cropKnowledge = new HashMap<>();
+
+    @Override
+    public void setCanUseCrop(Item crop, boolean canUse) {
+        cropKnowledge.put(crop, canUse);
+    }
+
+    @Override
+    public boolean canPlayerUseCrop(Item crop) {
+        return cropKnowledge.getOrDefault(crop, false);
+    }
+
+    @Override
+    public NBTTagCompound writeNBT() {
+        NBTTagCompound tag = new NBTTagCompound();
+        for (Item i : cropKnowledge.keySet()) {
+            tag.setBoolean(Item.itemRegistry.getNameForObject(i).toString(), cropKnowledge.get(i));
+        }
+        return tag;
+    }
+
+    @Override
+    public void readNBT(NBTTagCompound nbt) {
+        cropKnowledge.clear();
+        for (String key : nbt.getKeySet()) {
+            Item i = Item.getByNameOrId(key);
+            if (i != null) {
+                cropKnowledge.put(i, nbt.getBoolean(key));
+            }
+        }
+    }
+}

--- a/src/main/java/org/millenaire/capability/PlayerCropProvider.java
+++ b/src/main/java/org/millenaire/capability/PlayerCropProvider.java
@@ -1,0 +1,56 @@
+package org.millenaire.capability;
+
+import net.minecraft.nbt.NBTBase;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.EnumFacing;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.CapabilityInject;
+import net.minecraftforge.common.capabilities.CapabilityManager;
+import net.minecraftforge.common.capabilities.ICapabilitySerializable;
+
+public class PlayerCropProvider implements ICapabilitySerializable<NBTTagCompound> {
+
+    @CapabilityInject(IPlayerCropData.class)
+    public static final Capability<IPlayerCropData> CROP_CAPABILITY = null;
+
+    private IPlayerCropData instance = CROP_CAPABILITY == null ? null : CROP_CAPABILITY.getDefaultInstance();
+
+    public static void register() {
+        CapabilityManager.INSTANCE.register(IPlayerCropData.class, new Capability.IStorage<IPlayerCropData>() {
+            @Override
+            public NBTBase writeNBT(Capability<IPlayerCropData> capability, IPlayerCropData instance, EnumFacing side) {
+                return instance.writeNBT();
+            }
+
+            @Override
+            public void readNBT(Capability<IPlayerCropData> capability, IPlayerCropData instance, EnumFacing side, NBTBase nbt) {
+                instance.readNBT((NBTTagCompound) nbt);
+            }
+        }, PlayerCropData::new);
+    }
+
+    @Override
+    public boolean hasCapability(Capability<?> capability, EnumFacing facing) {
+        return capability == CROP_CAPABILITY;
+    }
+
+    @Override
+    public <T> T getCapability(Capability<T> capability, EnumFacing facing) {
+        if (capability == CROP_CAPABILITY) {
+            return CROP_CAPABILITY.cast(instance);
+        }
+        return null;
+    }
+
+    @Override
+    public NBTTagCompound serializeNBT() {
+        return instance == null ? new NBTTagCompound() : instance.writeNBT();
+    }
+
+    @Override
+    public void deserializeNBT(NBTTagCompound nbt) {
+        if (instance != null) {
+            instance.readNBT(nbt);
+        }
+    }
+}

--- a/src/main/java/org/millenaire/entities/EntityMillVillager.java
+++ b/src/main/java/org/millenaire/entities/EntityMillVillager.java
@@ -39,6 +39,9 @@ import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegistryObject;
 import net.minecraft.entity.EntityClassification;
 import net.minecraft.entity.EntityType;
+import net.minecraft.entity.DataParameter;
+import net.minecraft.entity.DataSerializers;
+import net.minecraft.entity.EntityDataManager;
 
 public class EntityMillVillager extends EntityCreature
 {
@@ -47,10 +50,10 @@ public class EntityMillVillager extends EntityCreature
         public int villagerID;
 	private MillCulture culture;
 	private VillagerType type;
-	private final static int TEXTURE = 13;
-	private final static int AGE = 14;
-	private final static int GENDER = 16;
-	private final static int NAME = 17;
+       private static final DataParameter<String> TEXTURE = EntityDataManager.createKey(EntityMillVillager.class, DataSerializers.STRING);
+       private static final DataParameter<Integer> AGE = EntityDataManager.createKey(EntityMillVillager.class, DataSerializers.VARINT);
+       private static final DataParameter<Integer> GENDER = EntityDataManager.createKey(EntityMillVillager.class, DataSerializers.VARINT);
+       private static final DataParameter<String> NAME = EntityDataManager.createKey(EntityMillVillager.class, DataSerializers.STRING);
 
 	private boolean isVillagerSleeping = false;
 	public boolean isPlayerInteracting = false;
@@ -106,39 +109,39 @@ public class EntityMillVillager extends EntityCreature
     }
 	
 	@Override
-	public void entityInit()
+       public void entityInit()
     {
         super.entityInit();
-        this.dataWatcher.addObject(TEXTURE, "texture");
-        this.dataWatcher.addObject(NAME, "name");
+        this.getDataManager().register(TEXTURE, "texture");
+        this.getDataManager().register(NAME, "name");
         //0 is Adult
-        this.dataWatcher.addObject(AGE, 0);
+        this.getDataManager().register(AGE, 0);
         //0 for male, 1 for female, 2 for Sym Female
-        this.dataWatcher.addObject(GENDER, 0);
+        this.getDataManager().register(GENDER, 0);
     }
 	
 	public EntityMillVillager setTypeAndGender(VillagerType typeIn, int genderIn)
 	{
-		this.type = typeIn;
-		this.dataWatcher.updateObject(GENDER, genderIn);
-		this.dataWatcher.updateObject(TEXTURE, type.getTexture());
-		return this;
-	}
+               this.type = typeIn;
+               this.getDataManager().set(GENDER, genderIn);
+               this.getDataManager().set(TEXTURE, type.getTexture());
+               return this;
+       }
 	
-	public void setChild() { this.dataWatcher.updateObject(AGE, 1); }
+       public void setChild() { this.getDataManager().set(AGE, 1); }
 	
-	public void setName(String nameIn) { this.dataWatcher.updateObject(NAME, nameIn); }
+       public void setName(String nameIn) { this.getDataManager().set(NAME, nameIn); }
 	
-	public String getTexture() { return this.dataWatcher.getWatchableObjectString(13); }
+       public String getTexture() { return this.getDataManager().get(TEXTURE); }
 	
-	public int getGender() { return dataWatcher.getWatchableObjectInt(GENDER); }
+       public int getGender() { return this.getDataManager().get(GENDER); }
 	
-	public String getName() { return this.dataWatcher.getWatchableObjectString(NAME); }
+       public String getName() { return this.getDataManager().get(NAME); }
 
 	public VillagerType getVillagerType() { return type; }
 	
 	@Override
-	public boolean isChild() { return (this.dataWatcher.getWatchableObjectInt(AGE) > 0); }
+       public boolean isChild() { return (this.getDataManager().get(AGE) > 0); }
 	
     public boolean allowLeashing() { return false; }
     
@@ -492,13 +495,13 @@ public class EntityMillVillager extends EntityCreature
 		super.writeToNBT(nbt);
 		nbt.setInteger("villagerID", villagerID);
 		nbt.setString("culture", culture.cultureName);
-		nbt.setInteger("gender", this.dataWatcher.getWatchableObjectInt(GENDER));
+               nbt.setInteger("gender", this.getDataManager().get(GENDER));
 		nbt.setString("villagerType", type.id);
 		nbt.setBoolean("sleeping", isVillagerSleeping);
 		
-		nbt.setString("texture", this.dataWatcher.getWatchableObjectString(TEXTURE));
-		nbt.setInteger("age", this.dataWatcher.getWatchableObjectInt(AGE));
-		nbt.setString("name", this.dataWatcher.getWatchableObjectString(NAME));
+               nbt.setString("texture", this.getDataManager().get(TEXTURE));
+               nbt.setInteger("age", this.getDataManager().get(AGE));
+               nbt.setString("name", this.getDataManager().get(NAME));
 		
 		NBTTagList nbttaglist = new NBTTagList();
         for (int i = 0; i < this.villagerInventory.getSizeInventory(); ++i)
@@ -533,13 +536,13 @@ public class EntityMillVillager extends EntityCreature
 			System.out.println("Fix this shit!");
 			culture.getChildType(GENDER);
 		}
-		this.dataWatcher.updateObject(GENDER, nbt.getInteger("gender"));
+               this.getDataManager().set(GENDER, nbt.getInteger("gender"));
 		type = culture.getVillagerType(nbt.getString("villagerType"));
 		isVillagerSleeping = nbt.getBoolean("sleeping");
 		
-		this.dataWatcher.updateObject(TEXTURE, nbt.getString("texture"));
-		this.dataWatcher.updateObject(AGE, nbt.getInteger("age"));
-		this.dataWatcher.updateObject(NAME, nbt.getString("name"));
+               this.getDataManager().set(TEXTURE, nbt.getString("texture"));
+               this.getDataManager().set(AGE, nbt.getInteger("age"));
+               this.getDataManager().set(NAME, nbt.getString("name"));
 		
 		NBTTagList nbttaglist = nbt.getTagList("Inventory", 10);
         for (int i = 0; i < nbttaglist.tagCount(); ++i)


### PR DESCRIPTION
## Summary
- replace deprecated `dataWatcher` usage in `EntityMillVillager` with `EntityDataManager`
- implement new player crop capability (`Capability<IPlayerCropData>`) with provider and events
- hook capability registration into mod setup
- update `PlayerTracker` as capability accessor

## Testing
- `./gradlew test --no-daemon --console=plain` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6871518126c88330b7313176f5ff080c