### PR TITLE
Update to Gradle 8.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,10 @@ java {
 
 version = "1.8.9-7.0.0-A2.3"
 group= "org.millenaire.millenaire" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
-archivesBaseName = "millenaire"
+
+base {
+    archivesName = "millenaire"
+}
 
 minecraft {
     version = "1.20.1-47.0.39"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip


### PR DESCRIPTION
## Summary
- bump Gradle wrapper to 8.4
- replace deprecated `archivesBaseName` with `archivesName`

## Testing
- `./gradlew --version` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6871f89461e48330bfd63c4626819c15