### PR TITLE
Add setup script for dependency installation

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# setup.sh -- prepare Gradle dependencies, then try to compile
+# This script should not fail even if the build does.
+
+echo "Downloading Gradle dependencies..."
+./gradlew --refresh-dependencies || true
+
+echo "Attempting to compile..."
+./gradlew build || true
+
+echo "Setup complete."
+


### PR DESCRIPTION
## Summary
- add `setup.sh` to fetch gradle deps before a compile attempt
- adjust script so that build failures don't abort setup

## Testing
- `./setup.sh` *(fails: compile errors, but script finishes)*


------
https://chatgpt.com/codex/tasks/task_e_68723b454a388330b7ff71d43053ee9f