### PR TITLE
Refactor item and block constructors

### DIFF
--- a/src/main/java/org/millenaire/blocks/BlockMillOre.java
+++ b/src/main/java/org/millenaire/blocks/BlockMillOre.java
@@ -2,10 +2,11 @@ package org.millenaire.blocks;
 
 import java.util.Random;
 
-import org.millenaire.Millenaire;
 import org.millenaire.items.MillItems;
 
+import net.minecraft.block.AbstractBlock;
 import net.minecraft.block.Block;
+import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.item.Item;
@@ -15,12 +16,12 @@ public class BlockMillOre extends Block {
 
 	private EnumMillOre oreType;
 	
-	BlockMillOre(EnumMillOre oretype) {
-		super(Material.rock);
-		this.oreType = oretype;
-		this.setCreativeTab(Millenaire.tabMillenaire);
-		this.setHarvestLevel("pickaxe", oretype.harvestLevel);
-	}
+        BlockMillOre(EnumMillOre oretype) {
+                super(AbstractBlock.Properties.of(Material.rock)
+                        .strength(3.0F, 3.0F)
+                        .sound(SoundType.STONE));
+                this.oreType = oretype;
+        }
 	
 	@Override
 	public Item getItemDropped(IBlockState state, Random rand, int fortune) { return oreType.itemDropped; }

--- a/src/main/java/org/millenaire/blocks/MillBlocks.java
+++ b/src/main/java/org/millenaire/blocks/MillBlocks.java
@@ -167,7 +167,7 @@ public class MillBlocks {
                 BLOCKS.register("block_mill_path_slab", () -> blockMillPathSlab);
                 BLOCKS.register("block_mill_path_slab_double", () -> blockMillPathSlabDouble);
 
-		//Ores
+                //Ores
                 galianiteOre = new BlockMillOre(BlockMillOre.EnumMillOre.GALIANITE);
                 BLOCKS.register("galianite_ore", () -> galianiteOre);
     	

--- a/src/main/java/org/millenaire/items/ItemBlockDecorativeStone.java
+++ b/src/main/java/org/millenaire/items/ItemBlockDecorativeStone.java
@@ -3,18 +3,17 @@ package org.millenaire.items;
 import org.millenaire.blocks.BlockDecorativeStone;
 
 import net.minecraft.block.Block;
-import net.minecraft.item.ItemBlock;
+import net.minecraft.item.BlockItem;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
-public class ItemBlockDecorativeStone extends ItemBlock
+public class ItemBlockDecorativeStone extends BlockItem
 {
 
-	public ItemBlockDecorativeStone(Block block) 
-	{
-		super(block);
-		this.setMaxDamage(0);
-		this.setHasSubtypes(true);
-	}
+       public ItemBlockDecorativeStone(Block block, Item.Properties properties)
+       {
+               super(block, properties);
+       }
 
 	public String getUnlocalizedName(ItemStack stack)
     {

--- a/src/main/java/org/millenaire/items/MillItems.java
+++ b/src/main/java/org/millenaire/items/MillItems.java
@@ -167,27 +167,27 @@ public class MillItems
 	
 	public static void preinitialize()
 	{
-		denier = new Item().setCreativeTab(Millenaire.tabMillenaire);
-		ITEMS.register("denier", () -> denier);
-		denierOr = new Item().setCreativeTab(Millenaire.tabMillenaire);
-		ITEMS.register("denier_or", () -> denierOr);
-		denierArgent = new Item().setCreativeTab(Millenaire.tabMillenaire);
-		ITEMS.register("denier_argent", () -> denierArgent);
+                denier = new Item(new Item.Properties().tab(Millenaire.tabMillenaire));
+                ITEMS.register("denier", () -> denier);
+                denierOr = new Item(new Item.Properties().tab(Millenaire.tabMillenaire));
+                ITEMS.register("denier_or", () -> denierOr);
+                denierArgent = new Item(new Item.Properties().tab(Millenaire.tabMillenaire));
+                ITEMS.register("denier_argent", () -> denierArgent);
 		
-		silk = new Item().setCreativeTab(Millenaire.tabMillenaire);
-		ITEMS.register("silk", () -> silk);
-		obsidianFlake = new Item().setCreativeTab(Millenaire.tabMillenaire);
-		ITEMS.register("obsidian_flake", () -> obsidianFlake);
-		unknownPowder = new Item().setCreativeTab(Millenaire.tabMillenaire);
-		ITEMS.register("unknown_powder", () -> unknownPowder);
+                silk = new Item(new Item.Properties().tab(Millenaire.tabMillenaire));
+                ITEMS.register("silk", () -> silk);
+                obsidianFlake = new Item(new Item.Properties().tab(Millenaire.tabMillenaire));
+                ITEMS.register("obsidian_flake", () -> obsidianFlake);
+                unknownPowder = new Item(new Item.Properties().tab(Millenaire.tabMillenaire));
+                ITEMS.register("unknown_powder", () -> unknownPowder);
 		
 		woolClothes = new Item().setCreativeTab(Millenaire.tabMillenaire);
 		ITEMS.register("wool_clothes", () -> woolClothes);
 		silkClothes = new Item().setCreativeTab(Millenaire.tabMillenaire);
 		ITEMS.register("silk_clothes", () -> silkClothes);
 		
-		galianiteDust = new Item().setCreativeTab(Millenaire.tabMillenaire);
-		ITEMS.register("galianite_dust", () -> galianiteDust);
+                galianiteDust = new Item(new Item.Properties().tab(Millenaire.tabMillenaire));
+                ITEMS.register("galianite_dust", () -> galianiteDust);
 		
 		//Crops
 		turmeric = new ItemMillSeeds(MillBlocks.cropTurmeric).setCreativeTab(Millenaire.tabMillenaire);


### PR DESCRIPTION
## Summary
- use `AbstractBlock.Properties` for the ore block
- move sample items to new `Item.Properties`
- convert one legacy `ItemBlock` to a `BlockItem`

## Testing
- `./gradlew --version`
- `./gradlew build` *(fails: ExceptionInInitializerError)*

------
https://chatgpt.com/codex/tasks/task_e_6873ab7299b483309a121c03ff736a7c