### PR TITLE
Update gui classes and use NetworkHooks

### DIFF
--- a/src/main/java/org/millenaire/blocks/BlockMillChest.java
+++ b/src/main/java/org/millenaire/blocks/BlockMillChest.java
@@ -11,8 +11,7 @@ import net.minecraft.block.BlockContainer;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.passive.EntityOcelot;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.inventory.InventoryLargeChest;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.tileentity.TileEntityChest;
 import net.minecraft.world.phys.AABB;
@@ -20,6 +19,14 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.world.ILockableContainer;
 import net.minecraft.world.World;
+import net.minecraftforge.network.NetworkHooks;
+import net.minecraft.world.MenuProvider;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.TextComponent;
+import net.minecraft.world.SimpleMenuProvider;
+import net.minecraft.server.level.ServerPlayer;
+import org.millenaire.gui.EmptyMenu;
+import org.millenaire.gui.MillMenus;
 
 public class BlockMillChest extends BlockChest
 {
@@ -43,16 +50,12 @@ public class BlockMillChest extends BlockChest
     }
 	
 	@Override
-	public boolean onBlockActivated(World worldIn, BlockPos pos, IBlockState state, EntityPlayer playerIn, EnumFacing side, float hitX, float hitY, float hitZ)
+        public boolean onBlockActivated(World worldIn, BlockPos pos, IBlockState state, Player playerIn, EnumFacing side, float hitX, float hitY, float hitZ)
     {
         if (!worldIn.isRemote)
         {
-            ILockableContainer ilockablecontainer = this.getLockableContainer(worldIn, pos);
-
-            if (ilockablecontainer != null)
-            {
-                playerIn.openGui(Millenaire.instance, 1, worldIn, pos.getX(), pos.getY(), pos.getZ());
-            }
+            MenuProvider provider = new SimpleMenuProvider((id, inv, player) -> new EmptyMenu(MillMenus.CHEST_MENU.get(), id), new TextComponent("Mill Chest"));
+            NetworkHooks.openGui((net.minecraft.server.level.ServerPlayer)playerIn, provider, pos);
         }
         return true;
     }

--- a/src/main/java/org/millenaire/blocks/BlockVillageStone.java
+++ b/src/main/java/org/millenaire/blocks/BlockVillageStone.java
@@ -11,7 +11,7 @@ import net.minecraft.entity.item.EntityTNTPrimed;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.core.BlockPos;
-import net.minecraft.util.ChatComponentText;
+import net.minecraft.network.chat.TextComponent;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.world.World;
 
@@ -35,10 +35,10 @@ public class BlockVillageStone extends BlockContainer
 	@Override
     public boolean onBlockActivated(World worldIn, BlockPos pos, IBlockState state, EntityPlayer playerIn, EnumFacing side, float hitX, float hitY, float hitZ)
     {
-		if(worldIn.isRemote)
-		{
-			playerIn.addChatMessage(new ChatComponentText("The Village name almost seems to shimmer in the twilight"));
-		}
+                if(worldIn.isRemote)
+                {
+                        playerIn.sendMessage(new TextComponent("The Village name almost seems to shimmer in the twilight"), playerIn.getUUID());
+                }
 		
 		TileEntityVillageStone te = (TileEntityVillageStone) worldIn.getTileEntity(pos);
 		if(te.testVar < 16)

--- a/src/main/java/org/millenaire/entities/TileEntityMillSign.java
+++ b/src/main/java/org/millenaire/entities/TileEntityMillSign.java
@@ -3,7 +3,7 @@ package org.millenaire.entities;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntitySign;
 import net.minecraft.core.BlockPos;
-import net.minecraft.util.ChatComponentText;
+import net.minecraft.network.chat.TextComponent;
 import net.minecraft.util.ITickable;
 
 public class TileEntityMillSign extends TileEntitySign implements ITickable
@@ -40,9 +40,9 @@ public class TileEntityMillSign extends TileEntitySign implements ITickable
 	{
 
 		if(!(villageStoneLocation == null)) {
-			signText[0] = new ChatComponentText("The End is Nigh");
+                        signText[0] = new TextComponent("The End is Nigh");
 			TileEntityVillageStone TEVS = (TileEntityVillageStone)this.getWorld().getTileEntity(villageStoneLocation);
-			signText[1] = new ChatComponentText(TEVS.testVar + " clicks");
+                        signText[1] = new TextComponent(TEVS.testVar + " clicks");
 
 			/*switch(thisSignType) {
 			case 1:

--- a/src/main/java/org/millenaire/entities/TileEntityVillageStone.java
+++ b/src/main/java/org/millenaire/entities/TileEntityVillageStone.java
@@ -19,7 +19,7 @@ import org.millenaire.village.Village;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.core.BlockPos;
-import net.minecraft.util.ChatComponentText;
+import net.minecraft.network.chat.TextComponent;
 import net.minecraft.world.World;
 
 public class TileEntityVillageStone extends TileEntity
@@ -71,8 +71,8 @@ public class TileEntityVillageStone extends TileEntity
 					{
 						if(!world.isRemote)
 						{
-							for(int i = 0; i < world.playerEntities.size(); i++)
-								world.playerEntities.get(i).addChatMessage(new ChatComponentText(culture + " village " + villageName + " discovered at " + pos.getX() + ", " + pos.getY() + ", " + pos.getZ()));
+                                                        for(int i = 0; i < world.playerEntities.size(); i++)
+                                                                world.playerEntities.get(i).sendMessage(new TextComponent(culture + " village " + villageName + " discovered at " + pos.getX() + ", " + pos.getY() + ", " + pos.getZ()), world.playerEntities.get(i).getUUID());
 						}
 					}
 

--- a/src/main/java/org/millenaire/gui/GuiChief.java
+++ b/src/main/java/org/millenaire/gui/GuiChief.java
@@ -3,19 +3,19 @@ package org.millenaire.gui;
 import org.millenaire.Millenaire;
 import org.millenaire.gui.GuiParchment.NextPageButton;
 
-import net.minecraft.client.gui.GuiButton;
-import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.util.ResourceLocation;
 
-public class GuiChief extends GuiScreen
+public class GuiChief extends Screen
 {
 	private final static ResourceLocation CHIEFGUI = new ResourceLocation(Millenaire.MODID + ":textures/gui/ML_village_chief.png");
 	private String string;
 	private int page = 0;
 	private int maxPage = 4;
 
-	private GuiButton forward;
-	private GuiButton backward;
+        private Button forward;
+        private Button backward;
 	
 	@Override
 	public void drawScreen(int mouseX, int mouseY, float partialTicks) 
@@ -31,13 +31,13 @@ public class GuiChief extends GuiScreen
 	@Override
 	public void initGui() 
 	{
-	    this.buttonList.add(this.backward = new NextPageButton(0, (this.width / 2) - 95, 208, false));
-	    this.buttonList.add(this.forward = new NextPageButton(1, (this.width / 2) + 77, 208, true));
+            this.buttonList.add(this.backward = new NextPageButton(0, (this.width / 2) - 95, 208, false));
+            this.buttonList.add(this.forward = new NextPageButton(1, (this.width / 2) + 77, 208, true));
 	    updateButtons();
 	}
 	
 	@Override
-	protected void actionPerformed(GuiButton button)
+        protected void actionPerformed(Button button)
 	{
 	    if (button == this.forward) 
 	    {

--- a/src/main/java/org/millenaire/gui/GuiMillChest.java
+++ b/src/main/java/org/millenaire/gui/GuiMillChest.java
@@ -4,20 +4,22 @@ import java.io.IOException;
 
 import org.millenaire.entities.TileEntityMillChest;
 
-import net.minecraft.client.gui.inventory.GuiChest;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.inventory.IInventory;
-import net.minecraft.util.ChatComponentTranslation;
-import net.minecraft.util.IChatComponent;
+import net.minecraft.client.gui.screens.inventory.ChestScreen;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.ChestMenu;
+import net.minecraft.world.Container;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.TranslatableComponent;
 
-public class GuiMillChest extends GuiChest
+public class GuiMillChest extends ChestScreen
 {
 	private boolean isLocked;
 
-	private IInventory lowerChestInventory;
+        private Inventory lowerChestInventory;
 	private TileEntityMillChest chest;
 	
-	GuiMillChest(IInventory playerInv, IInventory chestInv, EntityPlayer playerIn, TileEntityMillChest entityIn)
+        GuiMillChest(Inventory playerInv, Inventory chestInv, Player playerIn, TileEntityMillChest entityIn)
 	{
 		super(playerInv, chestInv);
 		System.out.println("GuiCreated");
@@ -30,16 +32,16 @@ public class GuiMillChest extends GuiChest
 	protected void drawGuiContainerForegroundLayer(int mouseX, int mouseY)
     {
 		chest.checkForAdjacentChests();
-		IChatComponent string;
-		if(chest.adjacentChestXNeg == null && chest.adjacentChestXPos == null && chest.adjacentChestZNeg == null && chest.adjacentChestZPos == null) {
-			string = (isLocked ? new ChatComponentTranslation("container.millChestLocked") : new ChatComponentTranslation("container.millChestUnlocked"));
-		}
-		else {
-			string = (isLocked ? new ChatComponentTranslation("container.millChestDoubleLocked") : new ChatComponentTranslation("container.millChestDoubleUnlocked"));
-		}
+                Component string;
+                if(chest.adjacentChestXNeg == null && chest.adjacentChestXPos == null && chest.adjacentChestZNeg == null && chest.adjacentChestZPos == null) {
+                        string = isLocked ? new TranslatableComponent("container.millChestLocked") : new TranslatableComponent("container.millChestUnlocked");
+                }
+                else {
+                        string = isLocked ? new TranslatableComponent("container.millChestDoubleLocked") : new TranslatableComponent("container.millChestDoubleUnlocked");
+                }
 		
-        this.fontRendererObj.drawString(string.getUnformattedText(), 8, 6, 4210752);
-        this.fontRendererObj.drawString(this.lowerChestInventory.getDisplayName().getUnformattedText(), 8, this.ySize - 96 + 2, 4210752);
+        this.fontRendererObj.drawString(string.getString(), 8, 6, 4210752);
+        this.fontRendererObj.drawString(this.lowerChestInventory.getDisplayName().getString(), 8, this.ySize - 96 + 2, 4210752);
     }
 
 	@Override

--- a/src/main/java/org/millenaire/gui/GuiOptions.java
+++ b/src/main/java/org/millenaire/gui/GuiOptions.java
@@ -3,19 +3,20 @@ package org.millenaire.gui;
 import org.millenaire.Millenaire;
 import org.millenaire.networking.MillPacket;
 
-import net.minecraft.client.gui.GuiButton;
-import net.minecraft.client.gui.GuiScreen;
-import net.minecraft.client.resources.I18n;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.resources.language.I18n;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.network.chat.Component;
 
-public class GuiOptions extends GuiScreen
+public class GuiOptions extends Screen
 {
 	private final static ResourceLocation OPTIONGUI = new ResourceLocation(Millenaire.MODID + ":textures/gui/ML_village_chief.png");
 	private String string;
 	private int eventID;
 
-	private GuiButton yes;
-	private GuiButton no;
+        private Button yes;
+        private Button no;
 
 	GuiOptions(int IDin, String stringIn)
 	{
@@ -36,12 +37,12 @@ public class GuiOptions extends GuiScreen
 	
 	public void initGui() 
 	{
-	    this.buttonList.add(this.yes = new GuiButton(0, (this.width / 2) - 50, (this.height / 2) + 40, 40, 20, "Yes"));
-	    this.buttonList.add(this.no = new GuiButton(1, (this.width / 2) + 10, (this.height / 2) + 40, 40, 20, "No"));
+            this.buttonList.add(this.yes = new Button((this.width / 2) - 50, (this.height / 2) + 40, 40, 20, Component.literal("Yes"), b -> {}));
+            this.buttonList.add(this.no = new Button((this.width / 2) + 10, (this.height / 2) + 40, 40, 20, Component.literal("No"), b -> {}));
 	}
 	
 	@Override
-	protected void actionPerformed(GuiButton button)
+        protected void actionPerformed(Button button)
 	{
 		if(button == this.yes)
 		{

--- a/src/main/java/org/millenaire/items/ItemMillParchment.java
+++ b/src/main/java/org/millenaire/items/ItemMillParchment.java
@@ -2,10 +2,17 @@ package org.millenaire.items;
 
 import org.millenaire.Millenaire;
 
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.item.ItemStack;
-import net.minecraft.item.ItemWritableBook;
-import net.minecraft.world.World;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.ItemWritableBook;
+import net.minecraft.world.level.Level;
+import net.minecraftforge.network.NetworkHooks;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.MenuProvider;
+import net.minecraft.network.chat.TextComponent;
+import net.minecraft.world.SimpleMenuProvider;
+import org.millenaire.gui.EmptyMenu;
+import org.millenaire.gui.MillMenus;
 
 public class ItemMillParchment extends ItemWritableBook
 {
@@ -19,12 +26,13 @@ public class ItemMillParchment extends ItemWritableBook
 	}
 	
 	@Override
-	public ItemStack onItemRightClick(ItemStack itemStackIn, World worldIn, EntityPlayer playerIn)
+        public ItemStack onItemRightClick(ItemStack itemStackIn, Level worldIn, Player playerIn)
     {
-		if(worldIn.isRemote)
-		{
-			playerIn.openGui(Millenaire.instance, 0, worldIn, playerIn.getPosition().getX(), playerIn.getPosition().getY(), playerIn.getPosition().getZ());
-		}
+                if(worldIn.isRemote)
+                {
+                        MenuProvider provider = new SimpleMenuProvider((id, inv, player) -> new EmptyMenu(MillMenus.PARCHMENT_MENU.get(), id), new TextComponent("Parchment"));
+                        NetworkHooks.openGui((ServerPlayer)playerIn, provider);
+                }
 		
         return itemStackIn;
     }


### PR DESCRIPTION
## Summary
- refactor old GUI classes to extend `Screen`
- replace deprecated text components with `Component`
- open the mill chest and parchment menus via `NetworkHooks`
- update some text messages to the new chat API

## Testing
- `./gradlew test` *(fails: Unable to start the daemon process)*

------
https://chatgpt.com/codex/tasks/task_e_6873b632be308330b0e3544f69fbb7e5