### PR TITLE
Port AI classes to Goal API

### DIFF
--- a/src/main/java/org/millenaire/entities/EntityMillVillager.java
+++ b/src/main/java/org/millenaire/entities/EntityMillVillager.java
@@ -17,11 +17,10 @@ import net.minecraft.client.renderer.entity.Render;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.entity.EntityCreature;
 import net.minecraft.entity.SharedMonsterAttributes;
-import net.minecraft.entity.ai.EntityAIOpenDoor;
-import net.minecraft.entity.ai.EntityAISwimming;
-import net.minecraft.entity.ai.EntityAIWander;
-import net.minecraft.entity.ai.EntityAIWatchClosest;
-import net.minecraft.entity.ai.EntityAIWatchClosest2;
+import net.minecraft.world.entity.ai.goal.OpenDoorGoal;
+import net.minecraft.world.entity.ai.goal.FloatGoal;
+import net.minecraft.world.entity.ai.goal.RandomStrollGoal;
+import net.minecraft.world.entity.ai.goal.LookAtPlayerGoal;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.InventoryBasic;
@@ -89,12 +88,12 @@ public class EntityMillVillager extends EntityCreature
 	{
 		//((PathNavigateGround)this.getNavigator()).setBreakDoors(true);
 		//((PathNavigateGround)this.getNavigator()).setAvoidsWater(true);
-        this.tasks.addTask(0, new EntityAISwimming(this));
-		this.tasks.addTask(1, new EntityAIOpenDoor(this, true));
-		this.tasks.addTask(1, new EntityAIGateOpen(this, true));
-		this.tasks.addTask(7, new EntityAIWatchClosest2(this, EntityPlayer.class, 3.0F, 0.5F));
-		this.tasks.addTask(8, new EntityAIWatchClosest(this, EntityMillVillager.class, 6.0F));
-		this.tasks.addTask(9, new EntityAIWander(this, 0.6D));
+        this.goalSelector.addGoal(0, new FloatGoal(this));
+                this.goalSelector.addGoal(1, new OpenDoorGoal(this, true));
+                this.goalSelector.addGoal(1, new EntityAIGateOpen(this, true));
+                this.goalSelector.addGoal(7, new LookAtPlayerGoal(this, EntityPlayer.class, 3.0F, 0.5F));
+                this.goalSelector.addGoal(8, new LookAtPlayerGoal(this, EntityMillVillager.class, 6.0F));
+                this.goalSelector.addGoal(9, new RandomStrollGoal(this, 0.6D));
 	}
 	
 	@Override

--- a/src/main/java/org/millenaire/entities/ai/EntityAIBuild.java
+++ b/src/main/java/org/millenaire/entities/ai/EntityAIBuild.java
@@ -2,14 +2,14 @@ package org.millenaire.entities.ai;
 
 import org.millenaire.entities.EntityMillVillager;
 
-import net.minecraft.entity.EntityLiving;
-import net.minecraft.entity.ai.EntityAIBase;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.ai.goal.Goal;
 
-public class EntityAIBuild extends EntityAIBase
+public class EntityAIBuild extends Goal
 {
-	private EntityLiving theEntity;
+        private LivingEntity theEntity;
 	
-	public EntityAIBuild(EntityLiving entityIn)
+        public EntityAIBuild(LivingEntity entityIn)
 	{
 		this.theEntity = entityIn;
 
@@ -23,22 +23,22 @@ public class EntityAIBuild extends EntityAIBase
         }
 	}
 
-	/**
-     * Returns whether the EntityAIBase should begin execution.
+    /**
+     * Returns whether the goal should begin execution.
      */
-	@Override
-	public boolean shouldExecute() { return false; }
+        @Override
+        public boolean canUse() { return false; }
 
 	/**
-     * Returns whether an in-progress EntityAIBase should continue executing
+     * Returns whether an in-progress goal should continue executing
      */
-	@Override
-    public boolean continueExecuting() { return false; }
+        @Override
+    public boolean canContinueToUse() { return false; }
 	
 	/**
      * Execute a one shot task or start executing a continuous task
      */
-    public void startExecuting()
+    public void start()
     {
     	
     }
@@ -46,7 +46,7 @@ public class EntityAIBuild extends EntityAIBase
     /**
      * Updates the task
      */
-    public void updateTask()
+    public void tick()
     {
     	
     }
@@ -55,7 +55,7 @@ public class EntityAIBuild extends EntityAIBase
      * Resets the task
      */
     @Override
-    public void resetTask()
+    public void stop()
     {
     	
     }

--- a/src/main/java/org/millenaire/entities/ai/EntityAIGateOpen.java
+++ b/src/main/java/org/millenaire/entities/ai/EntityAIGateOpen.java
@@ -4,17 +4,17 @@ import net.minecraft.block.Block;
 import net.minecraft.block.BlockFenceGate;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
-import net.minecraft.entity.EntityLiving;
-import net.minecraft.entity.ai.EntityAIBase;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.ai.goal.Goal;
 import net.minecraft.pathfinding.PathEntity;
 import net.minecraft.pathfinding.PathNavigateGround;
 import net.minecraft.pathfinding.PathPoint;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.World;
 
-public class EntityAIGateOpen extends EntityAIBase
+public class EntityAIGateOpen extends Goal
 {
-    private EntityLiving theEntity;
+    private LivingEntity theEntity;
     private BlockPos gatePosition = BlockPos.ORIGIN;
     /** The gate block */
     private BlockFenceGate gateBlock;
@@ -29,7 +29,7 @@ public class EntityAIGateOpen extends EntityAIBase
     /** The temporisation before the entity close the door (in ticks, always 20 = 1 second) */
     private int closeGateTemporisation;
 
-    public EntityAIGateOpen(EntityLiving entityIn, boolean shouldClose)
+    public EntityAIGateOpen(LivingEntity entityIn, boolean shouldClose)
     {
         this.theEntity = entityIn;
 
@@ -43,10 +43,10 @@ public class EntityAIGateOpen extends EntityAIBase
     }
 
     /**
-     * Returns whether the EntityAIBase should begin execution.
+     * Returns whether the goal should begin execution.
      */
     @Override
-    public boolean shouldExecute()
+    public boolean canUse()
     {
     	//System.out.println("AI called - should execute");
         if (!this.theEntity.isCollidedHorizontally)
@@ -90,19 +90,19 @@ public class EntityAIGateOpen extends EntityAIBase
     }
 
     /**
-     * Returns whether an in-progress EntityAIBase should continue executing
+     * Returns whether an in-progress goal should continue executing
      */
     @Override
-    public boolean continueExecuting()
+    public boolean canContinueToUse()
     {
-        return this.closeGate && this.closeGateTemporisation > 0 && super.continueExecuting();
+        return this.closeGate && this.closeGateTemporisation > 0;
     }
 
     /**
      * Execute a one shot task or start executing a continuous task
      */
     @Override
-    public void startExecuting()
+    public void start()
     {
         this.closeGateTemporisation = 20;
         this.toggleGate(gateBlock, this.theEntity.worldObj, this.gatePosition, true);
@@ -112,7 +112,7 @@ public class EntityAIGateOpen extends EntityAIBase
      * Updates the task
      */
     @Override
-    public void updateTask()
+    public void tick()
     {
     	--this.closeGateTemporisation;
     	
@@ -127,7 +127,7 @@ public class EntityAIGateOpen extends EntityAIBase
     }
     
     @Override
-    public void resetTask()
+    public void stop()
     {
         if (this.closeGate)
         {


### PR DESCRIPTION
## Summary
- port `EntityAIBuild` and `EntityAIGateOpen` to extend `net.minecraft.world.entity.ai.goal.Goal`
- update method names to the Goal API
- register goals using `goalSelector.addGoal`

## Testing
- `./gradlew test` *(fails: Unable to start the daemon process)*

------
https://chatgpt.com/codex/tasks/task_e_6873b9e502f08330a0211a254ea8f2a8