### PR TITLE
Add initial tags for bricks and galianite

### DIFF
--- a/src/main/resources/data/millenaire/loot_tables/blocks/galianite_ore.json
+++ b/src/main/resources/data/millenaire/loot_tables/blocks/galianite_ore.json
@@ -6,7 +6,7 @@
       "entries": [
         {
           "type": "minecraft:item",
-          "name": "millenaire:galianite_dust",
+          "name": "#millenaire:galianite_dust",
           "functions": [
             {"function": "minecraft:set_count", "count": 2},
             {"function": "minecraft:explosion_decay"}

--- a/src/main/resources/data/millenaire/recipes/mud_brick_smelting.json
+++ b/src/main/resources/data/millenaire/recipes/mud_brick_smelting.json
@@ -1,6 +1,6 @@
 {
   "type": "minecraft:smelting",
-  "ingredient": {"item": "millenaire:mud_brick"},
+  "ingredient": {"tag": "millenaire:mud_brick"},
   "result": "millenaire:cooked_brick",
   "experience": 0.3,
   "cookingtime": 200

--- a/src/main/resources/data/millenaire/tags/blocks/cooked_brick.json
+++ b/src/main/resources/data/millenaire/tags/blocks/cooked_brick.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "millenaire:cooked_brick"
+  ]
+}

--- a/src/main/resources/data/millenaire/tags/blocks/dried_brick.json
+++ b/src/main/resources/data/millenaire/tags/blocks/dried_brick.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "millenaire:dried_brick"
+  ]
+}

--- a/src/main/resources/data/millenaire/tags/blocks/galianite_ore.json
+++ b/src/main/resources/data/millenaire/tags/blocks/galianite_ore.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "millenaire:galianite_ore"
+  ]
+}

--- a/src/main/resources/data/millenaire/tags/blocks/mud_brick.json
+++ b/src/main/resources/data/millenaire/tags/blocks/mud_brick.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "millenaire:mud_brick"
+  ]
+}

--- a/src/main/resources/data/millenaire/tags/items/cooked_brick.json
+++ b/src/main/resources/data/millenaire/tags/items/cooked_brick.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "millenaire:cooked_brick"
+  ]
+}

--- a/src/main/resources/data/millenaire/tags/items/dried_brick.json
+++ b/src/main/resources/data/millenaire/tags/items/dried_brick.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "millenaire:dried_brick"
+  ]
+}

--- a/src/main/resources/data/millenaire/tags/items/galianite_dust.json
+++ b/src/main/resources/data/millenaire/tags/items/galianite_dust.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "millenaire:galianite_dust"
+  ]
+}

--- a/src/main/resources/data/millenaire/tags/items/mud_brick.json
+++ b/src/main/resources/data/millenaire/tags/items/mud_brick.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "millenaire:mud_brick"
+  ]
+}


### PR DESCRIPTION
## Summary
- create basic item/block tags for bricks and galianite materials
- use item tag in mud brick smelting recipe
- use item tag in galianite ore loot table

## Testing
- `./gradlew test` *(fails: Unable to start the daemon process)*

------
https://chatgpt.com/codex/tasks/task_e_6873c0c3c7648330994f2d5bed7a2fa8