### PR TITLE
Fix block placement and sound API

### DIFF
--- a/src/main/java/org/millenaire/blocks/BlockAlchemists.java
+++ b/src/main/java/org/millenaire/blocks/BlockAlchemists.java
@@ -5,6 +5,8 @@ import net.minecraft.block.material.Material;
 import net.minecraft.init.Blocks;
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.EnumParticleTypes;
+import net.minecraft.util.SoundCategory;
+import net.minecraft.init.SoundEvents;
 import net.minecraft.world.Explosion;
 import net.minecraft.world.World;
 
@@ -22,8 +24,8 @@ public class BlockAlchemists extends Block
 	private void alchemistExplosion(final World world, final int i, final int j, final int k)
 	{
 		world.setBlockToAir(new BlockPos(i, j, k));
-		world.spawnParticle(EnumParticleTypes.EXPLOSION_HUGE, i + 0.5D, j + 0.5D, k+ 0.5D, 0.0D, 0.0D, 0.0D);
-		world.playSoundEffect(i, j, k, "random.explode", 8.0F, (1.0F + (world.rand.nextFloat() - world.rand.nextFloat()) * 0.2F) * 0.9F);
+                world.spawnParticle(EnumParticleTypes.EXPLOSION_HUGE, i + 0.5D, j + 0.5D, k+ 0.5D, 0.0D, 0.0D, 0.0D);
+                world.playSound(null, new BlockPos(i, j, k), SoundEvents.ENTITY_GENERIC_EXPLODE, SoundCategory.BLOCKS, 8.0F, (1.0F + (world.rand.nextFloat() - world.rand.nextFloat()) * 0.2F) * 0.9F);
 		
 		for (int y = EXPLOSIONRADIUS; y >= -EXPLOSIONRADIUS; y--) 
 		{

--- a/src/main/java/org/millenaire/blocks/BlockDecorativeSodPlank.java
+++ b/src/main/java/org/millenaire/blocks/BlockDecorativeSodPlank.java
@@ -3,6 +3,7 @@ package org.millenaire.blocks;
 import java.util.List;
 
 import net.minecraft.block.Block;
+import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.properties.IProperty;
 import net.minecraft.block.properties.PropertyEnum;
@@ -23,8 +24,8 @@ public class BlockDecorativeSodPlank extends Block
 	{
 		super(Material.wood);
 		this.setHardness(2F);
-		this.setResistance(15F);
-		this.setStepSound(Block.soundTypeWood);
+                this.setResistance(15F);
+                this.setSoundType(SoundType.WOOD);
 	}
 	
 	@Override

--- a/src/main/java/org/millenaire/blocks/BlockDecorativeUpdate.java
+++ b/src/main/java/org/millenaire/blocks/BlockDecorativeUpdate.java
@@ -25,7 +25,7 @@ public class BlockDecorativeUpdate extends Block
 
         if (i > 1)
         {
-        	worldIn.setBlock(pos, updateState);
+                worldIn.setBlockState(pos, updateState);
         }
     }
 }

--- a/src/main/java/org/millenaire/blocks/BlockMillCrops.java
+++ b/src/main/java/org/millenaire/blocks/BlockMillCrops.java
@@ -52,7 +52,7 @@ public class BlockMillCrops extends BlockCrops
                 {
                 	if (rand.nextInt((int)(25.0F / f) + 1) == 0)
                 	{
-                		worldIn.setBlock(pos, state.withProperty(AGE, i + 1), 2);
+                                worldIn.setBlockState(pos, state.withProperty(AGE, i + 1), 2);
                 	}
                 }
             }

--- a/src/main/java/org/millenaire/blocks/BlockVillageStone.java
+++ b/src/main/java/org/millenaire/blocks/BlockVillageStone.java
@@ -13,6 +13,8 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.TextComponent;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.SoundCategory;
+import net.minecraft.init.SoundEvents;
 import net.minecraft.world.World;
 
 public class BlockVillageStone extends BlockContainer
@@ -67,7 +69,7 @@ public class BlockVillageStone extends BlockContainer
 		
 		te.willExplode = true;
 		worldIn.scheduleUpdate(pos, this, 60);
-		worldIn.playSoundEffect(pos.getX() + 0.5D, pos.getY()+ 0.5D, pos.getZ()+ 0.5D, "portal.portal", 1.0F, 0.01F);
+                worldIn.playSound(null, pos, SoundEvents.BLOCK_PORTAL_TRAVEL, SoundCategory.BLOCKS, 1.0F, 0.01F);
 	}
 	
 	@Override

--- a/src/main/java/org/millenaire/building/BuildingBlock.java
+++ b/src/main/java/org/millenaire/building/BuildingBlock.java
@@ -13,6 +13,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntityDispenser;
 import net.minecraft.tileentity.TileEntityMobSpawner;
 import net.minecraft.core.BlockPos;
+import net.minecraft.util.SoundCategory;
 import net.minecraft.world.World;
 import net.minecraft.world.gen.feature.WorldGenForest;
 import net.minecraft.world.gen.feature.WorldGenSavannaTree;
@@ -67,9 +68,8 @@ public class BuildingBlock
 	{
 		if (specialBlock != BuildingBlock.PRESERVEGROUNDDEPTH && specialBlock != BuildingBlock.PRESERVEGROUNDSURFACE && specialBlock != BuildingBlock.CLEARTREE) 
 		{
-			worldIn.setBlock(position, blockState);
-			String soundName = blockState.getBlock().stepSound.getPlaceSound();
-			worldIn.playSoundEffect(position.getX() + 0.5D, position.getY() + 0.5D, position.getZ() + 0.5D, soundName, 0.3F, 0.6F);
+                    worldIn.setBlockState(position, blockState);
+                    worldIn.playSound(null, position, blockState.getSoundType().getPlaceSound(), SoundCategory.BLOCKS, 0.3F, 0.6F);
 		}
 		
 		if (specialBlock == BuildingBlock.PRESERVEGROUNDDEPTH || specialBlock == BuildingBlock.PRESERVEGROUNDSURFACE) 
@@ -110,21 +110,18 @@ public class BuildingBlock
 				}
 
 				assert targetblock != null;
-				worldIn.setBlock(position, targetblock.getDefaultState());
-				String soundName = targetblock.stepSound.getPlaceSound();
-				worldIn.playSoundEffect(position.getX() + 0.5D, position.getY() + 0.5D, position.getZ() + 0.5D, soundName, 0.3F, 0.6F);
+                                worldIn.setBlockState(position, targetblock.getDefaultState());
+                                worldIn.playSound(null, position, targetblock.getSoundType().getPlaceSound(), SoundCategory.BLOCKS, 0.3F, 0.6F);
 			} 
 			else if (onGeneration && validGroundBlock == Blocks.dirt && worldIn.getBlockState(position.up()) == null) 
 			{
-				worldIn.setBlock(position, Blocks.grass.getDefaultState());
-				String soundName = Blocks.grass.stepSound.getPlaceSound();
-				worldIn.playSoundEffect(position.getX() + 0.5D, position.getY() + 0.5D, position.getZ() + 0.5D, soundName, 0.3F, 0.6F);
+                                worldIn.setBlockState(position, Blocks.grass.getDefaultState());
+                                worldIn.playSound(null, position, Blocks.grass.getSoundType().getPlaceSound(), SoundCategory.BLOCKS, 0.3F, 0.6F);
 			} 
 			else if (validGroundBlock != block && !(validGroundBlock == Blocks.dirt && block == Blocks.grass)) 
 			{
-				worldIn.setBlock(position, validGroundBlock.getDefaultState());
-				String soundName = validGroundBlock.stepSound.getPlaceSound();
-				worldIn.playSoundEffect(position.getX() + 0.5D, position.getY() + 0.5D, position.getZ() + 0.5D, soundName, 0.3F, 0.6F);
+                                worldIn.setBlockState(position, validGroundBlock.getDefaultState());
+                                worldIn.playSound(null, position, validGroundBlock.getSoundType().getPlaceSound(), SoundCategory.BLOCKS, 0.3F, 0.6F);
 			}
 		}
 		else if (specialBlock == BuildingBlock.CLEARTREE) 
@@ -133,9 +130,8 @@ public class BuildingBlock
 
 			if (block == Blocks.log || block == Blocks.leaves) 
 			{
-				worldIn.setBlockToAir(position);
-				String soundName = block.stepSound.getBreakSound();
-				worldIn.playSoundEffect(position.getX() + 0.5D, position.getY() + 0.5D, position.getZ() + 0.5D, soundName, 0.3F, 0.6F);
+                                worldIn.setBlockToAir(position);
+                                worldIn.playSound(null, position, block.getSoundType().getBreakSound(), SoundCategory.BLOCKS, 0.3F, 0.6F);
 
 				final Block blockBelow = worldIn.getBlockState(position.down()).getBlock();
 
@@ -143,11 +139,11 @@ public class BuildingBlock
 
 				if (onGeneration && targetBlock == Blocks.dirt) 
 				{
-					worldIn.setBlock(position.down(), Blocks.grass.getDefaultState());
+                                worldIn.setBlockState(position.down(), Blocks.grass.getDefaultState());
 				} 
 				else if (targetBlock != null) 
 				{
-					worldIn.setBlock(position.down(), targetBlock.getDefaultState());
+                                worldIn.setBlockState(position.down(), targetBlock.getDefaultState());
 				}
 			}
 
@@ -156,9 +152,8 @@ public class BuildingBlock
 		{
 			Block block = worldIn.getBlockState(position).getBlock();
 			
-			worldIn.setBlockToAir(position);
-			String soundName = block.stepSound.getBreakSound();
-			worldIn.playSoundEffect(position.getX() + 0.5D, position.getY() + 0.5D, position.getZ() + 0.5D, soundName, 0.3F, 0.6F);
+                        worldIn.setBlockToAir(position);
+                        worldIn.playSound(null, position, block.getSoundType().getBreakSound(), SoundCategory.BLOCKS, 0.3F, 0.6F);
 
 			final Block blockBelow = worldIn.getBlockState(position.down()).getBlock();
 
@@ -166,11 +161,11 @@ public class BuildingBlock
 
 			if (onGeneration && targetBlock == Blocks.dirt) 
 			{
-				worldIn.setBlock(position.down(), Blocks.grass.getDefaultState());
+                        worldIn.setBlockState(position.down(), Blocks.grass.getDefaultState());
 			} 
 			else if (targetBlock != null) 
 			{
-				worldIn.setBlock(position.down(), targetBlock.getDefaultState());
+                        worldIn.setBlockState(position.down(), targetBlock.getDefaultState());
 			}
 		}
 		else if (specialBlock == BuildingBlock.OAKSPAWN) 
@@ -240,43 +235,43 @@ public class BuildingBlock
 		}
 		else if (specialBlock == BuildingBlock.SPAWNERSKELETON) 
 		{
-			worldIn.setBlock(position, Blocks.mob_spawner.getDefaultState());
+                        worldIn.setBlockState(position, Blocks.mob_spawner.getDefaultState());
 			final TileEntityMobSpawner tileentitymobspawner = (TileEntityMobSpawner) worldIn.getTileEntity(position);
 			tileentitymobspawner.getSpawnerBaseLogic().setEntityName("Skeleton");
 		} 
 		else if (specialBlock == BuildingBlock.SPAWNERZOMBIE) 
 		{
-			worldIn.setBlock(position, Blocks.mob_spawner.getDefaultState());
+                        worldIn.setBlockState(position, Blocks.mob_spawner.getDefaultState());
 			final TileEntityMobSpawner tileentitymobspawner = (TileEntityMobSpawner) worldIn.getTileEntity(position);
 			tileentitymobspawner.getSpawnerBaseLogic().setEntityName("Zombie");
 		} 
 		else if (specialBlock == BuildingBlock.SPAWNERSPIDER) 
 		{
-			worldIn.setBlock(position, Blocks.mob_spawner.getDefaultState());
+                        worldIn.setBlockState(position, Blocks.mob_spawner.getDefaultState());
 			final TileEntityMobSpawner tileentitymobspawner = (TileEntityMobSpawner) worldIn.getTileEntity(position);
 			tileentitymobspawner.getSpawnerBaseLogic().setEntityName("Spider");
 		} 
 		else if (specialBlock == BuildingBlock.SPAWNERCAVESPIDER) 
 		{
-			worldIn.setBlock(position, Blocks.mob_spawner.getDefaultState());
+                        worldIn.setBlockState(position, Blocks.mob_spawner.getDefaultState());
 			final TileEntityMobSpawner tileentitymobspawner = (TileEntityMobSpawner) worldIn.getTileEntity(position);
 			tileentitymobspawner.getSpawnerBaseLogic().setEntityName("CaveSpider");
 		} 
 		else if (specialBlock == BuildingBlock.SPAWNERCREEPER) 
 		{
-			worldIn.setBlock(position, Blocks.mob_spawner.getDefaultState());
+                        worldIn.setBlockState(position, Blocks.mob_spawner.getDefaultState());
 			final TileEntityMobSpawner tileentitymobspawner = (TileEntityMobSpawner) worldIn.getTileEntity(position);
 			tileentitymobspawner.getSpawnerBaseLogic().setEntityName("Creeper");
 		} 
 		else if (specialBlock == BuildingBlock.SPAWNERBLAZE) 
 		{
-			worldIn.setBlock(position, Blocks.mob_spawner.getDefaultState());
+                        worldIn.setBlockState(position, Blocks.mob_spawner.getDefaultState());
 			final TileEntityMobSpawner tileentitymobspawner = (TileEntityMobSpawner) worldIn.getTileEntity(position);
 			tileentitymobspawner.getSpawnerBaseLogic().setEntityName("Blaze");
 		} 
 		else if (specialBlock == BuildingBlock.DISPENDERUNKNOWNPOWDER) 
 		{
-			worldIn.setBlock(position, Blocks.dispenser.getDefaultState());
+                        worldIn.setBlockState(position, Blocks.dispenser.getDefaultState());
 			final TileEntityDispenser dispenser = (TileEntityDispenser)worldIn.getTileEntity(position);
 			dispenser.addItemStack(new ItemStack(MillItems.unknownPowder, 2));
 		}

--- a/src/main/java/org/millenaire/building/PlanIO.java
+++ b/src/main/java/org/millenaire/building/PlanIO.java
@@ -195,7 +195,7 @@ public class PlanIO {
 			for(int x = 0; x < plan.width; x++) {
 				for(int y = 0; y < plan.height; y++) {
 					for(int z = 0; z < plan.length; z++) {
-						world.setBlock(new BlockPos(x + startPos.getX() + 1, y + startPos.getY() + plan.depth, z + startPos.getZ() + 1), blocks[y][z][x], 2);
+                                                world.setBlockState(new BlockPos(x + startPos.getX() + 1, y + startPos.getY() + plan.depth, z + startPos.getZ() + 1), blocks[y][z][x], 2);
 					}
 				}
 			}
@@ -212,7 +212,7 @@ public class PlanIO {
 		for(int x = 0; x < plan.width; x++) {
 			for(int y = 0; y < plan.height; y++) {
 				for(int z = 0; z < plan.length; z++) {
-					world.setBlock(new BlockPos(x + loc.position.getX(), y + loc.position.getY() + plan.depth, z + loc.position.getZ()), blocks[y][z][x], 2);
+                                        world.setBlockState(new BlockPos(x + loc.position.getX(), y + loc.position.getY() + plan.depth, z + loc.position.getZ()), blocks[y][z][x], 2);
 				}
 			}
 		}

--- a/src/main/java/org/millenaire/entities/EntityMillVillager.java
+++ b/src/main/java/org/millenaire/entities/EntityMillVillager.java
@@ -45,6 +45,8 @@ import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegistryObject;
 import net.minecraft.entity.EntityClassification;
 import net.minecraft.entity.EntityType;
+import net.minecraft.init.SoundEvents;
+import net.minecraft.util.SoundCategory;
 
 public class EntityMillVillager extends PathfinderMob
 {
@@ -213,7 +215,7 @@ public class EntityMillVillager extends PathfinderMob
 
 				final EntityArrow arrow = new EntityArrow(this.worldObj, this, (EntityLivingBase) entity, 1.6F, 12.0F);
 
-				this.worldObj.playSoundAtEntity(this, "random.bow", 1.0F, 1.0F / (this.getRNG().nextFloat() * 0.4F + 0.8F));
+                                this.worldObj.playSound(null, this.getPosition(), SoundEvents.ENTITY_ARROW_SHOOT, SoundCategory.PLAYERS, 1.0F, 1.0F / (this.getRNG().nextFloat() * 0.4F + 0.8F));
 				this.worldObj.spawnEntityInWorld(arrow);
 
 				attackTime = 60;

--- a/src/main/java/org/millenaire/entities/ai/EntityAIGateOpen.java
+++ b/src/main/java/org/millenaire/entities/ai/EntityAIGateOpen.java
@@ -156,12 +156,12 @@ public class EntityAIGateOpen extends Goal
     	
     	if(open)
     	{
-            worldIn.setBlock(pos, state.withProperty(BlockFenceGate.OPEN, true));
+            worldIn.setBlockState(pos, state.withProperty(BlockFenceGate.OPEN, true));
         }
     	
     	if(!open)
     	{
-            worldIn.setBlock(pos, state.withProperty(BlockFenceGate.OPEN, false));
+            worldIn.setBlockState(pos, state.withProperty(BlockFenceGate.OPEN, false));
         }
     }
 }

--- a/src/main/java/org/millenaire/generation/VillageGenerator.java
+++ b/src/main/java/org/millenaire/generation/VillageGenerator.java
@@ -37,9 +37,9 @@ public class VillageGenerator {
 		}
 		else {
 			EntityPlayer generatingPlayer = world.getClosestPlayer(pos.getX(), pos.getY(), pos.getZ(), -1);
-			if(rand.nextInt(50) == 1 && world.getChunkFromBlockCoords(pos).isLoaded()) {
-				world.setBlock(pos, MillBlocks.villageStone.getDefaultState());
-			}
+                        if(rand.nextInt(50) == 1 && world.getChunkFromBlockCoords(pos).isLoaded()) {
+                                world.setBlockState(pos, MillBlocks.villageStone.getDefaultState());
+                        }
 			return false;
 		}
 	}

--- a/src/main/java/org/millenaire/items/ItemMillBow.java
+++ b/src/main/java/org/millenaire/items/ItemMillBow.java
@@ -11,6 +11,8 @@ import net.minecraft.init.Items;
 import net.minecraft.item.ItemBow;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
+import net.minecraft.util.SoundCategory;
+import net.minecraft.init.SoundEvents;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
@@ -81,7 +83,7 @@ public class ItemMillBow extends ItemBow
 			}
 
 			stack.damageItem(1, playerIn);
-			worldIn.playSoundAtEntity(playerIn, "random.bow", 1.0F, 1.0F / (itemRand.nextFloat() * 0.4F + 1.2F) + var7 * 0.5F);
+                        worldIn.playSound(null, playerIn.getPosition(), SoundEvents.ENTITY_ARROW_SHOOT, SoundCategory.PLAYERS, 1.0F, 1.0F / (itemRand.nextFloat() * 0.4F + 1.2F) + var7 * 0.5F);
 
 			if (var5)
 			{

--- a/src/main/java/org/millenaire/items/ItemMillSign.java
+++ b/src/main/java/org/millenaire/items/ItemMillSign.java
@@ -43,7 +43,7 @@ public class ItemMillSign extends Item
 			}
 			else
 			{
-				worldIn.setBlock(pos, MillBlocks.blockMillSign.getDefaultState().withProperty(BlockMillSign.FACING, side)/*Blocks.wall_sign.getDefaultState().withProperty(BlockWallSign.FACING, side)*/, 3);
+                                worldIn.setBlockState(pos, MillBlocks.blockMillSign.getDefaultState().withProperty(BlockMillSign.FACING, side)/*Blocks.wall_sign.getDefaultState().withProperty(BlockWallSign.FACING, side)*/, 3);
 
 
 				--stack.stackSize;

--- a/src/main/java/org/millenaire/items/ItemMillWand.java
+++ b/src/main/java/org/millenaire/items/ItemMillWand.java
@@ -235,7 +235,7 @@ public class ItemMillWand extends Item
                 }
 				else
 				{
-                    worldIn.setBlock(pos, worldIn.getBlockState(pos).cycleProperty(StoredPosition.VARIANT));
+                    worldIn.setBlockState(pos, worldIn.getBlockState(pos).cycleProperty(StoredPosition.VARIANT));
                 }
 			}
 			//Fixes All Denier in your inventory (if no specific block/entity is clicked)

--- a/src/main/java/org/millenaire/networking/MillPacket.java
+++ b/src/main/java/org/millenaire/networking/MillPacket.java
@@ -12,6 +12,8 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
+import net.minecraft.util.SoundCategory;
+import net.minecraft.init.SoundEvents;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraftforge.fmllegacy.network.simpleimpl.IMessage;
 import net.minecraftforge.fmllegacy.network.simpleimpl.IMessageHandler;
@@ -96,7 +98,7 @@ public class MillPacket implements IMessage
                                                 CompoundTag nbt = heldItem.getTag();
                                                 int id = nbt.getInteger("ID");
                                                 world.createExplosion(world.getEntityByID(id), world.getEntityByID(id).posX, world.getEntityByID(id).posY, world.getEntityByID(id).posZ, 0.0F, false);
-                                                world.playSoundAtEntity(world.getEntityByID(id), "game.player.hurt", 1.0F, 0.4F);
+                                                world.playSound(null, world.getEntityByID(id).getPosition(), SoundEvents.ENTITY_PLAYER_HURT, SoundCategory.PLAYERS, 1.0F, 0.4F);
                                                 world.removeEntity(world.getEntityByID(id));
                                         } else {
                                                 System.err.println("Player not holding Wand of Negation when attempting to delete Villager");
@@ -110,7 +112,7 @@ public class MillPacket implements IMessage
                                                 int posX = nbt.getInteger("X");
                                                 int posY = nbt.getInteger("Y");
                                                 int posZ = nbt.getInteger("Z");
-                                                world.setBlock(new BlockPos(posX, posY, posZ), MillBlocks.villageStone.getDefaultState());
+                                                world.setBlockState(new BlockPos(posX, posY, posZ), MillBlocks.villageStone.getDefaultState());
                                         } else {
                                                 System.err.println("Player not holding Wand of Summoning when attempting to create Village");
                                         }
@@ -186,7 +188,7 @@ public class MillPacket implements IMessage
 					int id = nbt.getInteger("ID");
 					
 					world.createExplosion(world.getEntityByID(id), world.getEntityByID(id).posX, world.getEntityByID(id).posY, world.getEntityByID(id).posZ, 0.0F, false);
-					world.playSoundAtEntity(world.getEntityByID(id), "game.player.hurt", 1.0F, 0.4F);
+                                        world.playSound(null, world.getEntityByID(id).getPosition(), SoundEvents.ENTITY_PLAYER_HURT, SoundCategory.PLAYERS, 1.0F, 0.4F);
 					//Will need to be actual removal (without respawn).
 					world.removeEntity(world.getEntityByID(id));
 				}
@@ -206,7 +208,7 @@ public class MillPacket implements IMessage
 					int posY = nbt.getInteger("Y");
 					int posZ = nbt.getInteger("Z");
 					
-					world.setBlock(new BlockPos(posX, posY, posZ), MillBlocks.villageStone.getDefaultState());
+                                        world.setBlockState(new BlockPos(posX, posY, posZ), MillBlocks.villageStone.getDefaultState());
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
- update block placement to use `setBlockState`
- use `playSound` for block and entity sounds
- remove deprecated `stepSound` usages

## Testing
- `./gradlew test` *(fails: ExceptionInInitializerError)*

------
https://chatgpt.com/codex/tasks/task_e_6873cfbc4fd88330bb90a10577d95703