### PR TITLE
Add color handler and tile entity renderers

### DIFF
--- a/src/main/java/org/millenaire/Millenaire.java
+++ b/src/main/java/org/millenaire/Millenaire.java
@@ -13,6 +13,7 @@ import org.millenaire.gui.MillChestScreen;
 import org.millenaire.gui.OptionsScreen;
 import org.millenaire.gui.ChiefScreen;
 import org.millenaire.items.MillItems;
+import org.millenaire.items.ItemMillAmulet;
 import org.millenaire.networking.MillNetwork;
 import org.millenaire.capability.PlayerCropProvider;
 import org.millenaire.capability.CapabilityEvents;
@@ -22,6 +23,10 @@ import net.minecraft.item.ItemGroup;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Item;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.color.ItemColors;
+import net.minecraft.client.renderer.tileentity.TileEntityChestRenderer;
+import net.minecraft.client.renderer.tileentity.TileEntitySignRenderer;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
@@ -32,6 +37,7 @@ import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.event.server.FMLServerStartingEvent;
 import net.minecraftforge.fml.client.registry.ScreenManager;
+import net.minecraftforge.fml.client.registry.ClientRegistry;
 import net.minecraftforge.network.NetworkRegistry;
 import net.minecraftforge.network.simple.SimpleChannel;
 import net.minecraftforge.fml.relauncher.Side;
@@ -113,6 +119,19 @@ public class Millenaire
                 ScreenManager.registerFactory(MillMenus.CHEST_MENU.get(), MillChestScreen::new);
                 ScreenManager.registerFactory(MillMenus.OPTIONS_MENU.get(), OptionsScreen::new);
                 ScreenManager.registerFactory(MillMenus.CHIEF_MENU.get(), ChiefScreen::new);
+
+                // Bind tile entity renderers
+                ClientRegistry.bindTileEntityRenderer(MillBlocks.MILL_CHEST_TILE.get(), TileEntityChestRenderer::new);
+                ClientRegistry.bindTileEntityRenderer(MillBlocks.MILL_SIGN_TILE.get(), TileEntitySignRenderer::new);
+
+                // Register item color handlers
+                ItemColors colors = Minecraft.getInstance().getItemColors();
+                colors.register((stack, tint) ->
+                        stack.getItem() instanceof ItemMillAmulet ?
+                                ((ItemMillAmulet) stack.getItem()).getColor(stack, tint) : 0xFFFFFF,
+                        MillItems.amuletAlchemist,
+                        MillItems.amuletVishnu,
+                        MillItems.amuletYggdrasil);
 
                 isServer = false;
         }

--- a/src/main/java/org/millenaire/items/ItemMillAmulet.java
+++ b/src/main/java/org/millenaire/items/ItemMillAmulet.java
@@ -148,34 +148,33 @@ public class ItemMillAmulet extends Item
 		stack.setTagCompound(nbt);
 	}
 
-	@Override
-	@SideOnly(Side.CLIENT)
-	public int getColorFromItemStack(ItemStack stack, int renderPass)
-	{
-		NBTTagCompound nbt = stack.getTagCompound();
+       @SideOnly(Side.CLIENT)
+       public int getColor(ItemStack stack, int tintIndex)
+       {
+               NBTTagCompound nbt = stack.getTagCompound();
 
-		if(renderPass != 0)
-		{
-			if(nbt== null)
-			{
-				if(this == MillItems.amuletAlchemist)
-					return colorAlchemist[0];
-				if(this == MillItems.amuletVishnu)
-					return colorVishnu[0];
-				if(this == MillItems.amuletYggdrasil)
-					return colorYggdrasil[16];
-			}
-			int score = nbt.getInteger("score");
+               if(tintIndex != 0)
+               {
+                       if(nbt== null)
+                       {
+                               if(this == MillItems.amuletAlchemist)
+                                       return colorAlchemist[0];
+                               if(this == MillItems.amuletVishnu)
+                                       return colorVishnu[0];
+                               if(this == MillItems.amuletYggdrasil)
+                                       return colorYggdrasil[16];
+                       }
+                       int score = nbt.getInteger("score");
 
-			if(this == MillItems.amuletAlchemist)
-				return colorAlchemist[score];
-			if(this == MillItems.amuletVishnu)
-				return colorVishnu[score];
-			if(this == MillItems.amuletYggdrasil)
-				return colorYggdrasil[score];
-		}
-		return 16777215;
-	}
+                       if(this == MillItems.amuletAlchemist)
+                               return colorAlchemist[score];
+                       if(this == MillItems.amuletVishnu)
+                               return colorVishnu[score];
+                       if(this == MillItems.amuletYggdrasil)
+                               return colorYggdrasil[score];
+               }
+               return 16777215;
+       }
 
 	public int getItemStackLimit(ItemStack stack) { return 1; }
 


### PR DESCRIPTION
## Summary
- bind default chest and sign renderers using `ClientRegistry`
- register item color handler for amulet items
- expose color logic through `ItemMillAmulet.getColor`

## Testing
- `./gradlew test --no-daemon` *(fails: java.lang.ExceptionInInitializerError)*

------
https://chatgpt.com/codex/tasks/task_e_6873d67839248330b82f6460ad29470e