### PR TITLE
Update block names for modern Minecraft

### DIFF
--- a/src/main/java/org/millenaire/CommonUtilities.java
+++ b/src/main/java/org/millenaire/CommonUtilities.java
@@ -90,24 +90,24 @@ public class CommonUtilities
 	 */
 	public static Block getValidGroundBlock(final Block b, final boolean surface) 
 	{
-		if (b == Blocks.bedrock || b == Blocks.dirt ||
-			b == Blocks.grass) {
-            return Blocks.dirt;
-		} else if (b == Blocks.stone) {
-		    if (surface) {
-                return Blocks.dirt;
+                if (b == Blocks.BEDROCK || b == Blocks.DIRT ||
+                        b == Blocks.GRASS_BLOCK) {
+            return Blocks.DIRT;
+                } else if (b == Blocks.STONE) {
+                    if (surface) {
+                return Blocks.DIRT;
             } else {
-                return Blocks.grass;
+                return Blocks.GRASS_BLOCK;
             }
-        } else if (b == Blocks.gravel) {
-		    return Blocks.gravel;
-        } else if (b == Blocks.sand) {
-		    return Blocks.sand;
-        } else if (b == Blocks.sandstone) {
-		    if (surface) {
-                return Blocks.sand;
+        } else if (b == Blocks.GRAVEL) {
+                    return Blocks.GRAVEL;
+        } else if (b == Blocks.SAND) {
+                    return Blocks.SAND;
+        } else if (b == Blocks.SANDSTONE) {
+                    if (surface) {
+                return Blocks.SAND;
             } else {
-                return Blocks.sandstone;
+                return Blocks.SANDSTONE;
             }
         }
 

--- a/src/main/java/org/millenaire/VillageGeography.java
+++ b/src/main/java/org/millenaire/VillageGeography.java
@@ -130,7 +130,7 @@ public class VillageGeography
 
 	private static boolean isForbiddenBlockForConstruction(final Block block)
 	{
-		return block == Blocks.water || block == Blocks.flowing_water || block == Blocks.ice || block == Blocks.flowing_lava || block == Blocks.lava || block == Blocks.planks || block == Blocks.cobblestone || block == Blocks.brick_block || block == Blocks.chest || block == Blocks.glass || block == Blocks.stonebrick || block == Blocks.prismarine
+        return block == Blocks.WATER || block == Blocks.ICE || block == Blocks.LAVA || block == Blocks.OAK_PLANKS || block == Blocks.COBBLESTONE || block == Blocks.BRICKS || block == Blocks.CHEST || block == Blocks.GLASS || block == Blocks.STONE_BRICKS || block == Blocks.PRISMARINE
 				|| block instanceof BlockWall || block instanceof BlockFence || block == MillBlocks.blockDecorativeEarth || block == MillBlocks.blockDecorativeStone || block == MillBlocks.blockDecorativeWood || block == MillBlocks.byzantineTile || block == MillBlocks.byzantineTileSlab || block == MillBlocks.byzantineStoneTile || block == MillBlocks.paperWall || block == MillBlocks.emptySericulture;
 	}
 	
@@ -321,7 +321,7 @@ public class VillageGeography
 
 				while (block != null && (isBlockSolid(block) || block instanceof BlockLiquid || !onground)) 
 				{
-					if (block == Blocks.log) 
+                                        if (block == Blocks.OAK_LOG)
 					{
 						heightDone = true;
 					} 
@@ -380,15 +380,15 @@ public class VillageGeography
 				final Block soilBlock = chunk.getBlock(i, y - 1, j);
 				block = chunk.getBlock(i, y, j);
 
-                water[mx][mz] = (block == Blocks.flowing_water || block == Blocks.water);
+                water[mx][mz] = (block == Blocks.WATER);
 
-				tree[mx][mz] = (soilBlock == Blocks.log);
+                                tree[mx][mz] = (soilBlock == Blocks.OAK_LOG);
 
 				path[mx][mz] = (soilBlock == MillBlocks.blockMillPath || soilBlock == MillBlocks.blockMillPathSlab || soilBlock == MillBlocks.blockMillPathSlabDouble);
 
 				boolean blocked = false;
 
-				if (!(soilBlock instanceof BlockFence) && !(soilBlock instanceof BlockWall) && !isBlockSolid(block) && block != Blocks.flowing_water && soilBlock != Blocks.water) 
+                if (!(soilBlock instanceof BlockFence) && !(soilBlock instanceof BlockWall) && !isBlockSolid(block) && block != Blocks.WATER && soilBlock != Blocks.WATER)
 				{
 					spaceAbove[mx][mz] = 1;
 				} 
@@ -397,7 +397,7 @@ public class VillageGeography
 					blocked = true;
 				}
 
-				if (block == Blocks.flowing_lava || block == Blocks.lava) 
+                                if (block == Blocks.LAVA)
 				{
 					danger[mx][mz] = true;
 				} 
@@ -728,14 +728,14 @@ public class VillageGeography
 
     private static boolean isBlockIdGround(final Block b)
 	{
-        return (b == Blocks.bedrock || b == Blocks.clay || b == Blocks.dirt ||
-                b == Blocks.grass || b == Blocks.gravel || b == Blocks.obsidian ||
-                b == Blocks.sand || b == Blocks.farmland);
+        return (b == Blocks.BEDROCK || b == Blocks.CLAY || b == Blocks.DIRT ||
+                b == Blocks.GRASS_BLOCK || b == Blocks.GRAVEL || b == Blocks.OBSIDIAN ||
+                b == Blocks.SAND || b == Blocks.FARMLAND);
 	}
 
     private static boolean isBlockIdGroundOrCeiling(final Block b)
 	{
-		return (b == Blocks.stone || b == Blocks.sandstone);
+                return (b == Blocks.STONE || b == Blocks.SANDSTONE);
 	}
 	
 	private static boolean isBlockSolid(Block block)

--- a/src/main/java/org/millenaire/blocks/BlockAlchemists.java
+++ b/src/main/java/org/millenaire/blocks/BlockAlchemists.java
@@ -38,8 +38,8 @@ public class BlockAlchemists extends Block
 						if (x * x + y * y + z * z <= EXPLOSIONRADIUS * EXPLOSIONRADIUS) 
 						{
 							world.spawnParticle(EnumParticleTypes.SMOKE_NORMAL, i, j + 0.5D, k, 0.0D, 0.0D, 0.0D);
-							final Block block = world.getBlockState(new BlockPos(i + x, j + y, k + z)).getBlock();
-							if (block != Blocks.air) 
+                                                        final Block block = world.getBlockState(new BlockPos(i + x, j + y, k + z)).getBlock();
+                                                        if (block != Blocks.AIR)
 							{
 								world.setBlockToAir(new BlockPos(i + x, j + y, k + z));
 							}

--- a/src/main/java/org/millenaire/building/BuildingBlock.java
+++ b/src/main/java/org/millenaire/building/BuildingBlock.java
@@ -92,33 +92,33 @@ public class BuildingBlock
 					below = below.down();
 				}
 
-				if (targetblock == Blocks.dirt && onGeneration) 
-				{
-					targetblock = Blocks.grass;
-				} 
-				else if (targetblock == Blocks.grass && !onGeneration) 
-				{
-					targetblock = Blocks.dirt;
-				}
+                                if (targetblock == Blocks.DIRT && onGeneration)
+                                {
+                                        targetblock = Blocks.GRASS_BLOCK;
+                                }
+                                else if (targetblock == Blocks.GRASS_BLOCK && !onGeneration)
+                                {
+                                        targetblock = Blocks.DIRT;
+                                }
 
-				if (targetblock == Blocks.air) 
-				{
-					if (onGeneration) 
-						targetblock = Blocks.grass;
-					else
-						targetblock = Blocks.dirt;
-				}
+                                if (targetblock == Blocks.AIR)
+                                {
+                                        if (onGeneration)
+                                                targetblock = Blocks.GRASS_BLOCK;
+                                        else
+                                                targetblock = Blocks.DIRT;
+                                }
 
 				assert targetblock != null;
                                 worldIn.setBlockState(position, targetblock.getDefaultState());
                                 worldIn.playSound(null, position, targetblock.getSoundType().getPlaceSound(), SoundCategory.BLOCKS, 0.3F, 0.6F);
 			} 
-			else if (onGeneration && validGroundBlock == Blocks.dirt && worldIn.getBlockState(position.up()) == null) 
-			{
-                                worldIn.setBlockState(position, Blocks.grass.getDefaultState());
-                                worldIn.playSound(null, position, Blocks.grass.getSoundType().getPlaceSound(), SoundCategory.BLOCKS, 0.3F, 0.6F);
-			} 
-			else if (validGroundBlock != block && !(validGroundBlock == Blocks.dirt && block == Blocks.grass)) 
+                        else if (onGeneration && validGroundBlock == Blocks.DIRT && worldIn.getBlockState(position.up()) == null)
+                        {
+                                worldIn.setBlockState(position, Blocks.GRASS_BLOCK.getDefaultState());
+                                worldIn.playSound(null, position, Blocks.GRASS_BLOCK.getSoundType().getPlaceSound(), SoundCategory.BLOCKS, 0.3F, 0.6F);
+                        }
+                        else if (validGroundBlock != block && !(validGroundBlock == Blocks.DIRT && block == Blocks.GRASS_BLOCK))
 			{
                                 worldIn.setBlockState(position, validGroundBlock.getDefaultState());
                                 worldIn.playSound(null, position, validGroundBlock.getSoundType().getPlaceSound(), SoundCategory.BLOCKS, 0.3F, 0.6F);
@@ -128,7 +128,7 @@ public class BuildingBlock
 		{
 			Block block = worldIn.getBlockState(position).getBlock();
 
-			if (block == Blocks.log || block == Blocks.leaves) 
+                        if (block == Blocks.OAK_LOG || block == Blocks.OAK_LEAVES)
 			{
                                 worldIn.setBlockToAir(position);
                                 worldIn.playSound(null, position, block.getSoundType().getBreakSound(), SoundCategory.BLOCKS, 0.3F, 0.6F);
@@ -137,10 +137,10 @@ public class BuildingBlock
 
 				final Block targetBlock = CommonUtilities.getValidGroundBlock(blockBelow, true);
 
-				if (onGeneration && targetBlock == Blocks.dirt) 
-				{
-                                worldIn.setBlockState(position.down(), Blocks.grass.getDefaultState());
-				} 
+                                if (onGeneration && targetBlock == Blocks.DIRT)
+                                {
+                                worldIn.setBlockState(position.down(), Blocks.GRASS_BLOCK.getDefaultState());
+                                }
 				else if (targetBlock != null) 
 				{
                                 worldIn.setBlockState(position.down(), targetBlock.getDefaultState());
@@ -159,10 +159,10 @@ public class BuildingBlock
 
 			final Block targetBlock = CommonUtilities.getValidGroundBlock(blockBelow, true);
 
-			if (onGeneration && targetBlock == Blocks.dirt) 
-			{
-                        worldIn.setBlockState(position.down(), Blocks.grass.getDefaultState());
-			} 
+                        if (onGeneration && targetBlock == Blocks.DIRT)
+                        {
+                        worldIn.setBlockState(position.down(), Blocks.GRASS_BLOCK.getDefaultState());
+                        }
 			else if (targetBlock != null) 
 			{
                         worldIn.setBlockState(position.down(), targetBlock.getDefaultState());
@@ -177,7 +177,7 @@ public class BuildingBlock
 			}
 			else
 			{
-				WorldGenerator wg = new WorldGenTrees(true, 4 + CommonUtilities.random.nextInt(7), Blocks.log.getDefaultState().withProperty(BlockOldLog.VARIANT, BlockPlanks.EnumType.OAK), Blocks.leaves.getDefaultState().withProperty(BlockOldLeaf.VARIANT, BlockPlanks.EnumType.OAK), false);
+                                WorldGenerator wg = new WorldGenTrees(true, 4 + CommonUtilities.random.nextInt(7), Blocks.OAK_LOG.getDefaultState().withProperty(BlockOldLog.VARIANT, BlockPlanks.EnumType.OAK), Blocks.OAK_LEAVES.getDefaultState().withProperty(BlockOldLeaf.VARIANT, BlockPlanks.EnumType.OAK), false);
 				wg.generate(worldIn, CommonUtilities.random, position);
 			}
 		} 
@@ -211,12 +211,12 @@ public class BuildingBlock
 		{
 			if (onGeneration) 
 			{
-				WorldGenerator wg = new WorldGenTrees(false, 4 + CommonUtilities.random.nextInt(7), Blocks.log.getDefaultState().withProperty(BlockOldLog.VARIANT, BlockPlanks.EnumType.JUNGLE), Blocks.leaves.getDefaultState().withProperty(BlockOldLeaf.VARIANT, BlockPlanks.EnumType.JUNGLE), true);
+                                WorldGenerator wg = new WorldGenTrees(false, 4 + CommonUtilities.random.nextInt(7), Blocks.OAK_LOG.getDefaultState().withProperty(BlockOldLog.VARIANT, BlockPlanks.EnumType.JUNGLE), Blocks.OAK_LEAVES.getDefaultState().withProperty(BlockOldLeaf.VARIANT, BlockPlanks.EnumType.JUNGLE), true);
 				wg.generate(worldIn, CommonUtilities.random, position);
 			}
 			else
 			{
-				WorldGenerator wg = new WorldGenTrees(true, 4 + CommonUtilities.random.nextInt(7), Blocks.log.getDefaultState().withProperty(BlockOldLog.VARIANT, BlockPlanks.EnumType.JUNGLE), Blocks.leaves.getDefaultState().withProperty(BlockOldLeaf.VARIANT, BlockPlanks.EnumType.JUNGLE), true);
+                                WorldGenerator wg = new WorldGenTrees(true, 4 + CommonUtilities.random.nextInt(7), Blocks.OAK_LOG.getDefaultState().withProperty(BlockOldLog.VARIANT, BlockPlanks.EnumType.JUNGLE), Blocks.OAK_LEAVES.getDefaultState().withProperty(BlockOldLeaf.VARIANT, BlockPlanks.EnumType.JUNGLE), true);
 				wg.generate(worldIn, CommonUtilities.random, position);
 			}
 		}

--- a/src/main/java/org/millenaire/building/BuildingPlan.java
+++ b/src/main/java/org/millenaire/building/BuildingPlan.java
@@ -258,7 +258,7 @@ public class BuildingPlan
 	
 	private boolean freeBuild(IBlockState state)
 	{
-		return state.getBlock() == Blocks.dirt || state.getBlock() == Blocks.water || state.getBlock() == Blocks.leaves || state.getBlock() == Blocks.leaves2 || state.getBlock() == Blocks.grass || state.getBlock() == Blocks.tallgrass || state.getBlock() == Blocks.red_flower || state.getBlock() == Blocks.yellow_flower || state.getBlock() == Blocks.double_plant || state.getBlock() == Blocks.deadbush
+                return state.getBlock() == Blocks.DIRT || state.getBlock() == Blocks.WATER || state.getBlock() == Blocks.OAK_LEAVES || state.getBlock() == Blocks.ACACIA_LEAVES || state.getBlock() == Blocks.GRASS_BLOCK || state.getBlock() == Blocks.TALL_GRASS || state.getBlock() == Blocks.POPPY || state.getBlock() == Blocks.DANDELION || state.getBlock() == Blocks.LILAC || state.getBlock() == Blocks.DEAD_BUSH
 				|| state.getBlock() == MillBlocks.blockMillPath || state.getBlock() == MillBlocks.blockMillPathSlab || state.equals(MillBlocks.blockDecorativeEarth.getDefaultState().withProperty(BlockDecorativeEarth.VARIANT, BlockDecorativeEarth.EnumType.DIRTWALL));
 	}
 	
@@ -293,18 +293,18 @@ public class BuildingPlan
                                                plankAcaciaCost += 4;
                                        else if (state.is(BlockTags.DARK_OAK_LOGS))
                                                plankJungleCost += 4;
-					else if (state.getBlock() == Blocks.planks && state.getValue(BlockPlanks.VARIANT) == BlockPlanks.EnumType.OAK)
-						plankOakCost++;
-					else if (state.getBlock() == Blocks.planks && state.getValue(BlockPlanks.VARIANT) == BlockPlanks.EnumType.SPRUCE)
-						plankSpruceCost++;
-					else if (state.getBlock() == Blocks.planks && state.getValue(BlockPlanks.VARIANT) == BlockPlanks.EnumType.BIRCH)
-						plankBirchCost++;
-					else if (state.getBlock() == Blocks.planks && state.getValue(BlockPlanks.VARIANT) == BlockPlanks.EnumType.JUNGLE)
-						plankJungleCost++;
-					else if (state.getBlock() == Blocks.planks && state.getValue(BlockPlanks.VARIANT) == BlockPlanks.EnumType.ACACIA)
-						plankAcaciaCost++;
-					else if (state.getBlock() == Blocks.planks && state.getValue(BlockPlanks.VARIANT) == BlockPlanks.EnumType.DARK_OAK)
-						plankDarkCost++;
+                                        else if (state.getBlock() == Blocks.OAK_PLANKS)
+                                                plankOakCost++;
+                                        else if (state.getBlock() == Blocks.SPRUCE_PLANKS)
+                                                plankSpruceCost++;
+                                        else if (state.getBlock() == Blocks.BIRCH_PLANKS)
+                                                plankBirchCost++;
+                                        else if (state.getBlock() == Blocks.JUNGLE_PLANKS)
+                                                plankJungleCost++;
+                                        else if (state.getBlock() == Blocks.ACACIA_PLANKS)
+                                                plankAcaciaCost++;
+                                        else if (state.getBlock() == Blocks.DARK_OAK_PLANKS)
+                                                plankDarkCost++;
 					else if (state.getBlock() == MillBlocks.byzantineTile)
 						byzBricksHalf += 2;
 					else if (state.getBlock() == MillBlocks.byzantineTileSlab)
@@ -449,7 +449,7 @@ public class BuildingPlan
                                        }
 					else if (state.getBlock() == MillBlocks.emptySericulture)
 						plankCost += 4;
-					else if (state.getBlock() != Blocks.air && !freeBuild(state))
+                                        else if (state.getBlock() != Blocks.AIR && !freeBuild(state))
 					{
 						addToCost(new ItemStack(state.getBlock(), 1, state.getBlock().getMetaFromState(state)), 1);
 					}
@@ -797,8 +797,8 @@ public class BuildingPlan
 
 					BlockPos p = adjustForOrientation(x, y + i + depth, z, j - lengthOffset, ak - widthOffset, orientation);
 
-					if (state.getBlock() == Blocks.air) 
-					{
+                                        if (state.getBlock() == Blocks.AIR)
+                                        {
 						bblocks.add(new BuildingBlock(state, p));
 					}
 				}
@@ -860,10 +860,10 @@ public class BuildingPlan
 					
 					setReferencePositions(state, p, location);
 
-					if (state.getBlock() != null && state.getBlock() != Blocks.air && firstPass(state)) 
-					{
-						if(state.getBlock() == Blocks.farmland)
-							state = Blocks.dirt.getDefaultState();
+                                        if (state.getBlock() != null && state.getBlock() != Blocks.AIR && firstPass(state))
+                                        {
+                                                if(state.getBlock() == Blocks.FARMLAND)
+                                                        state = Blocks.DIRT.getDefaultState();
 						
 						bblocks.add(new BuildingBlock(state, p));
 					}
@@ -957,11 +957,11 @@ public class BuildingPlan
 				special = 0;
 			}
 			
-			if ((state == bb.blockState && special == 0 || block == Blocks.grass && bb.blockState.getBlock() == Blocks.dirt) && bb.specialBlock == 0) 
-				toDelete[i] = true;
-			else if (bb.specialBlock == BuildingBlock.CLEARTREE && block != Blocks.log && block != Blocks.leaves)
-				toDelete[i] = true;
-			else if (bb.specialBlock == BuildingBlock.CLEARGROUND && (block == null || block == Blocks.air))
+                        if ((state == bb.blockState && special == 0 || block == Blocks.GRASS_BLOCK && bb.blockState.getBlock() == Blocks.DIRT) && bb.specialBlock == 0)
+                                toDelete[i] = true;
+                        else if (bb.specialBlock == BuildingBlock.CLEARTREE && block != Blocks.OAK_LOG && block != Blocks.OAK_LEAVES)
+                                toDelete[i] = true;
+                        else if (bb.specialBlock == BuildingBlock.CLEARGROUND && (block == null || block == Blocks.AIR))
 				toDelete[i] = true;
 			else if (bb.specialBlock == BuildingBlock.PRESERVEGROUNDDEPTH && CommonUtilities.getValidGroundBlock(block, false) == block)
 				toDelete[i] = true;

--- a/src/main/java/org/millenaire/building/PlanIO.java
+++ b/src/main/java/org/millenaire/building/PlanIO.java
@@ -118,14 +118,14 @@ public class PlanIO {
 					for (int z = 0; z < length; z++) {
 						IBlockState block = player.getEntityWorld().getBlockState(new BlockPos(x + startPoint.getX() + 1, y + startPoint.getY() + startLevel, z + startPoint.getZ() + 1));
 
-						if(block.getBlock() != Blocks.air) {
+                                                if(block.getBlock() != Blocks.AIR) {
 							blockFound = true;
 						}
-						if(saveSnow || block.getBlock() != Blocks.snow) {
+                                                if(saveSnow || block.getBlock() != Blocks.SNOW) {
 							level[x][z] = block;
 						}
 						else {
-							level[x][z] = Blocks.air.getDefaultState();
+                                                        level[x][z] = Blocks.AIR.getDefaultState();
 						}
 					}
 				}

--- a/src/main/java/org/millenaire/entities/EntityMillVillager.java
+++ b/src/main/java/org/millenaire/entities/EntityMillVillager.java
@@ -306,8 +306,8 @@ public class EntityMillVillager extends PathfinderMob
 	
 	/*public void detrampleCrops() 
 	{
-		if (getPosition().sameBlock(prevPoint) && (previousBlock == Blocks.wheat || previousBlock instanceof BlockMillCrops) && getBlock(getPosition()) != Blocks.air
-				&& getBlock(getPosition().getBelow()) == Blocks.dirt) {
+                if (getPosition().sameBlock(prevPoint) && (previousBlock == Blocks.WHEAT || previousBlock instanceof BlockMillCrops) && getBlock(getPosition()) != Blocks.AIR
+                                && getBlock(getPosition().getBelow()) == Blocks.DIRT) {
 			setBlock(getPosition(), previousBlock);
 			setBlockMetadata(getPosition(), previousBlockMeta);
 			setBlock(getPosition().getBelow(), Blocks.farmland);


### PR DESCRIPTION
## Summary
- switch to new enum-style block constants (DIRT, GRASS_BLOCK, etc.)
- update references to wood log and leaf blocks
- replace deprecated block checks in plans and utilities

## Testing
- `gradle wrapper` *(fails: Found Gradle version Gradle 8.14. Versions Gradle 6.0.0 and newer are not supported in FG3)*

------
https://chatgpt.com/codex/tasks/task_e_687400f4048c8330bf76ca4db9d46ef1