### PR TITLE
Replace legacy world/position fields

### DIFF
--- a/src/main/java/org/millenaire/entities/EntityMillVillager.java
+++ b/src/main/java/org/millenaire/entities/EntityMillVillager.java
@@ -157,7 +157,7 @@ public class EntityMillVillager extends PathfinderMob
     @Override
     public void onDeath(DamageSource cause)
     {
-    	InventoryHelper.dropInventoryItems(this.worldObj, this.getPosition(), this.villagerInventory);
+        InventoryHelper.dropInventoryItems(this.level, this.getPosition(), this.villagerInventory);
     }
     
     //Controls what happens when Villager encounters an Item on ground
@@ -213,10 +213,10 @@ public class EntityMillVillager extends PathfinderMob
 					}
 				}
 
-				final EntityArrow arrow = new EntityArrow(this.worldObj, this, (EntityLivingBase) entity, 1.6F, 12.0F);
+                                final EntityArrow arrow = new EntityArrow(this.level, this, (EntityLivingBase) entity, 1.6F, 12.0F);
 
-                                this.worldObj.playSound(null, this.getPosition(), SoundEvents.ENTITY_ARROW_SHOOT, SoundCategory.PLAYERS, 1.0F, 1.0F / (this.getRNG().nextFloat() * 0.4F + 0.8F));
-				this.worldObj.spawnEntityInWorld(arrow);
+                                this.level.playSound(null, this.getPosition(), SoundEvents.ENTITY_ARROW_SHOOT, SoundCategory.PLAYERS, 1.0F, 1.0F / (this.getRNG().nextFloat() * 0.4F + 0.8F));
+                                this.level.spawnEntityInWorld(arrow);
 
 				attackTime = 60;
 
@@ -257,9 +257,9 @@ public class EntityMillVillager extends PathfinderMob
 
 					if (!isRaider) {
 						if (!vtype.hostile) {
-							MillCommonUtilities.getServerProfile(player.worldObj, player.getDisplayName()).adjustReputation(getTownHall(), (int) (-i * 10));
+                                                        MillCommonUtilities.getServerProfile(player.level, player.getDisplayName()).adjustReputation(getTownHall(), (int) (-i * 10));
 						}
-						if (worldObj.difficultySetting != EnumDifficulty.PEACEFUL && this.getHealth() < getMaxHealth() - 10) {
+                                                if (level.difficultySetting != EnumDifficulty.PEACEFUL && this.getHealth() < getMaxHealth() - 10) {
 							entityToAttack = entity;
 							clearGoal();
 							if (getTownHall() != null) {
@@ -267,7 +267,7 @@ public class EntityMillVillager extends PathfinderMob
 							}
 						}
 
-						if (hadFullHealth && (player.getMainHandItem() == null || MillCommonUtilities.getItemWeaponDamage(player.getMainHandItem().getItem()) <= 1) && !worldObj.isRemote) {
+                                                if (hadFullHealth && (player.getMainHandItem() == null || MillCommonUtilities.getItemWeaponDamage(player.getMainHandItem().getItem()) <= 1) && !level.isRemote) {
 							ServerSender.sendTranslatedSentence(player, MLN.ORANGE, "ui.communicationexplanations");
 						}
 					}
@@ -387,13 +387,13 @@ public class EntityMillVillager extends PathfinderMob
 		if(type.hireCost > 0)
 		{
 			this.isPlayerInteracting = true;
-			playerIn.openGui(Millenaire.instance, 5, playerIn.worldObj, this.getPosition().getX(), this.getPosition().getY(), this.getPosition().getZ());
+                        playerIn.openGui(Millenaire.instance, 5, playerIn.level, this.getPosition().getX(), this.getPosition().getY(), this.getPosition().getZ());
 			return true;
 		}
 		if(type.isChief)
 		{
 			this.isPlayerInteracting = true;
-			playerIn.openGui(Millenaire.instance, 4, playerIn.worldObj, this.getPosition().getX(), this.getPosition().getY(), this.getPosition().getZ());
+                        playerIn.openGui(Millenaire.instance, 4, playerIn.level, this.getPosition().getX(), this.getPosition().getY(), this.getPosition().getZ());
 			return true;
 		}
 		//for Sadhu and Alchemist maitrepenser achievement
@@ -451,7 +451,7 @@ public class EntityMillVillager extends PathfinderMob
 		
 		if(isPlayerInteracting)
 		{
-			List<Player> playersNear = this.worldObj.getEntitiesWithinAABB(Player.class, new AABB(posX - 5, posY - 1, posZ - 5, posX + 5, posY + 1, posZ + 5));
+                        List<Player> playersNear = this.level.getEntitiesWithinAABB(Player.class, new AABB(getX() - 5, getY() - 1, getZ() - 5, getX() + 5, getY() + 1, getZ() + 5));
 			
 			if(playersNear.isEmpty())
 				isPlayerInteracting = false;
@@ -577,7 +577,7 @@ public class EntityMillVillager extends PathfinderMob
 	@Override
 	public String toString() 
 	{
-		return this.getClass().getSimpleName() + "@" + ": " + getName() + "/" + this.villagerID + "/" + worldObj;
+                return this.getClass().getSimpleName() + "@" + ": " + getName() + "/" + this.villagerID + "/" + level;
 	}
 	
 	//Update Texture for Byzantines with silk clothes, possibly further expand on this

--- a/src/main/java/org/millenaire/entities/ai/EntityAIGateOpen.java
+++ b/src/main/java/org/millenaire/entities/ai/EntityAIGateOpen.java
@@ -66,7 +66,7 @@ public class EntityAIGateOpen extends Goal
                     PathPoint pathpoint = pathentity.getPathPointFromIndex(i);
                     this.gatePosition = new BlockPos(pathpoint.xCoord, pathpoint.yCoord, pathpoint.zCoord);
 
-                    if (this.theEntity.getDistanceSq((double)this.gatePosition.getX(), this.theEntity.posY, (double)this.gatePosition.getZ()) <= 2.25D)
+                    if (this.theEntity.getDistanceSq((double)this.gatePosition.getX(), this.theEntity.getY(), (double)this.gatePosition.getZ()) <= 2.25D)
                     {
                     	System.out.println("gate check");
                         this.gateBlock = this.getBlockGate(this.gatePosition);
@@ -105,7 +105,7 @@ public class EntityAIGateOpen extends Goal
     public void start()
     {
         this.closeGateTemporisation = 20;
-        this.toggleGate(gateBlock, this.theEntity.worldObj, this.gatePosition, true);
+        this.toggleGate(gateBlock, this.theEntity.level, this.gatePosition, true);
     }
 
     /**
@@ -116,8 +116,8 @@ public class EntityAIGateOpen extends Goal
     {
     	--this.closeGateTemporisation;
     	
-        float f = (float)((double)((float)this.gatePosition.getX() + 0.5F) - this.theEntity.posX);
-        float f1 = (float)((double)((float)this.gatePosition.getZ() + 0.5F) - this.theEntity.posZ);
+        float f = (float)((double)((float)this.gatePosition.getX() + 0.5F) - this.theEntity.getX());
+        float f1 = (float)((double)((float)this.gatePosition.getZ() + 0.5F) - this.theEntity.getZ());
         float f2 = this.entityPositionX * f + this.entityPositionZ * f1;
 
         if (f2 < 0.0F)
@@ -131,13 +131,13 @@ public class EntityAIGateOpen extends Goal
     {
         if (this.closeGate)
         {
-            this.toggleGate(gateBlock, this.theEntity.worldObj, this.gatePosition, false);
+            this.toggleGate(gateBlock, this.theEntity.level, this.gatePosition, false);
         }
     }
 
     private BlockFenceGate getBlockGate(BlockPos pos)
     {
-        Block block = this.theEntity.worldObj.getBlockState(pos).getBlock();
+        Block block = this.theEntity.level.getBlockState(pos).getBlock();
         return block instanceof BlockFenceGate && block.getMaterial() == Material.wood ? (BlockFenceGate)block : null;
     }
     

--- a/src/main/java/org/millenaire/items/ItemMillAmulet.java
+++ b/src/main/java/org/millenaire/items/ItemMillAmulet.java
@@ -124,7 +124,7 @@ public class ItemMillAmulet extends Item
 
 		if(this == MillItems.amuletYggdrasil && entityIn instanceof Player)
 		{
-			int level = (int) Math.floor(entityIn.posY);
+                        int level = (int) Math.floor(entityIn.getY());
 
 			if(level > 255)
 			{

--- a/src/main/java/org/millenaire/networking/MillPacket.java
+++ b/src/main/java/org/millenaire/networking/MillPacket.java
@@ -61,7 +61,7 @@ public class MillPacket
                                                 Level world = sendingPlayer.level;
                                                 CompoundTag nbt = heldItem.getTag();
                                                 int id = nbt.getInteger("ID");
-                                                world.createExplosion(world.getEntityByID(id), world.getEntityByID(id).posX, world.getEntityByID(id).posY, world.getEntityByID(id).posZ, 0.0F, false);
+                                                world.createExplosion(world.getEntityByID(id), world.getEntityByID(id).getX(), world.getEntityByID(id).getY(), world.getEntityByID(id).getZ(), 0.0F, false);
                                                 world.playSound(null, world.getEntityByID(id).getPosition(), SoundEvents.ENTITY_PLAYER_HURT, SoundCategory.PLAYERS, 1.0F, 0.4F);
                                                 world.removeEntity(world.getEntityByID(id));
                                         } else {


### PR DESCRIPTION
## Summary
- update world field `worldObj` to `level`
- use `getX()`/`getY()`/`getZ()` instead of deprecated position fields

## Testing
- `gradle test` *(fails: Found Gradle version Gradle 8.14.3. Versions Gradle 6.0.0 and newer are not supported in FG3, FG4 however supports Versions 6.8.1 and newer)*

------
https://chatgpt.com/codex/tasks/task_e_6883e0af16888330a65f5803ff306834