### PR TITLE
Add voxel shapes for custom blocks

### DIFF
--- a/src/main/java/org/millenaire/blocks/BlockDecorativeCarving.java
+++ b/src/main/java/org/millenaire/blocks/BlockDecorativeCarving.java
@@ -8,6 +8,9 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.phys.shapes.VoxelShape;
+import net.minecraft.world.phys.shapes.CollisionContext;
+import net.minecraft.block.Block;
 
 public class BlockDecorativeCarving extends BlockDecorativeOriented {
 
@@ -15,34 +18,24 @@ public class BlockDecorativeCarving extends BlockDecorativeOriented {
                 super(materialIn);
         }
 
-	@Override
-	public boolean isOpaqueCube() { return false; }
+        /**
+         * Old bounding box logic handled via {@code setBlockBoundsBasedOnState}
+         * has been replaced with voxel shapes.
+         */
+        private static final VoxelShape NS_SHAPE = Block.box(4.0D, 0.0D, 0.0D, 12.0D, 8.0D, 16.0D);
+        private static final VoxelShape EW_SHAPE = Block.box(0.0D, 0.0D, 4.0D, 16.0D, 8.0D, 12.0D);
 
-	@Override
-	public boolean isFullBlock() { return false; }
+        @Override
+        public VoxelShape getShape(BlockState state, BlockGetter worldIn, BlockPos pos, CollisionContext context) {
+                return state.getValue(FACING).getAxis() == Direction.Axis.Z ? NS_SHAPE : EW_SHAPE;
+        }
 
-	@Override
-    public boolean isFullCube() { return false; }
+        @Override
+        public VoxelShape getCollisionShape(BlockState state, BlockGetter worldIn, BlockPos pos, CollisionContext context) {
+                return getShape(state, worldIn, pos, context);
+        }
 
     @SideOnly(Side.CLIENT)
     public float getAmbientOcclusionLightValue() { return 0.85F; }
 
-	@Override
-        public void setBlockBoundsBasedOnState(BlockGetter worldIn, BlockPos pos)
-        {
-                BlockState iblockstate = worldIn.getBlockState(pos);
-
-		if (iblockstate.getBlock() == this)
-		{
-                        if (iblockstate.getValue(FACING) == Direction.NORTH || iblockstate.getValue(FACING) == Direction.SOUTH)
-			{
-				this.setBlockBounds(0.25F, 0.0F, 0.0F, 0.75F, 0.5F, 1.0F);
-			}
-			else
-			{
-				this.setBlockBounds(0.0F, 0.0F, 0.25F, 1.0F, 0.5F, 0.75F);
-			}
-		}
-
-	}
 }

--- a/src/main/java/org/millenaire/blocks/BlockMillPath.java
+++ b/src/main/java/org/millenaire/blocks/BlockMillPath.java
@@ -7,6 +7,10 @@ import net.minecraft.block.material.Material;
 import net.minecraft.block.properties.IProperty;
 import net.minecraft.block.properties.PropertyEnum;
 import net.minecraft.block.BlockState;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.phys.shapes.VoxelShape;
+import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -22,14 +26,22 @@ public class BlockMillPath extends Block
 	{
 		super(Material.ground);
 		
-		this.setBlockBounds(0.0F, 0.0F, 0.0F, 1.0F, 0.9375F, 1.0F);
-	}
-	
-	@Override
-    public boolean isFullCube() { return false; }
-	
-	@Override
-    public boolean isOpaqueCube() { return false; }
+                // old bounding box handled via setBlockBounds. Replaced by
+                // static voxel shapes in getShape/getCollisionShape.
+        }
+
+        /** Height of the path is 15/16 of a block. */
+        private static final VoxelShape SHAPE = Block.box(0.0D, 0.0D, 0.0D, 16.0D, 15.0D, 16.0D);
+
+        @Override
+        public VoxelShape getShape(BlockState state, BlockGetter worldIn, BlockPos pos, CollisionContext context) {
+                return SHAPE;
+        }
+
+        @Override
+        public VoxelShape getCollisionShape(BlockState state, BlockGetter worldIn, BlockPos pos, CollisionContext context) {
+                return SHAPE;
+        }
 	
 
 	public IProperty getVariantProperty() { return VARIANT; }

--- a/src/main/java/org/millenaire/blocks/BlockMillPathSlab.java
+++ b/src/main/java/org/millenaire/blocks/BlockMillPathSlab.java
@@ -16,6 +16,10 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
+import net.minecraft.block.Block;
+import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.phys.shapes.VoxelShape;
+import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
@@ -29,12 +33,12 @@ public class BlockMillPathSlab extends BlockSlab
 		super(Material.ground);
 
 		if(this.isDouble())
-        	this.setDefaultState(this.blockState.getBaseState().withProperty(SEAMLESS, true));
+                this.setDefaultState(this.blockState.getBaseState().withProperty(SEAMLESS, true));
         else
-        	this.setDefaultState(this.blockState.getBaseState().withProperty(HALF, BlockSlab.EnumBlockHalf.BOTTOM));
-		
-		this.useNeighborBrightness = true;
-	}
+                this.setDefaultState(this.blockState.getBaseState().withProperty(HALF, BlockSlab.EnumBlockHalf.BOTTOM));
+
+                this.useNeighborBrightness = true;
+        }
 	
 	@Override
 	public boolean isDouble() { return false; }
@@ -48,11 +52,25 @@ public class BlockMillPathSlab extends BlockSlab
     @SideOnly(Side.CLIENT)
     public Item getItem(World worldIn, BlockPos pos) { return Item.getItemFromBlock(MillBlocks.blockMillPathSlab); }
     
-	@Override
-    public boolean isFullCube() { return false; }
-	
-	@Override
-    public boolean isOpaqueCube() { return false; }
+        /**
+         * Shapes replacing the old setBlockBounds based logic.
+         */
+        private static final VoxelShape DOUBLE_SHAPE = Block.box(0.0D, 0.0D, 0.0D, 16.0D, 15.0D, 16.0D);
+        private static final VoxelShape TOP_SHAPE = Block.box(0.0D, 8.0D, 0.0D, 16.0D, 15.0D, 16.0D);
+        private static final VoxelShape BOTTOM_SHAPE = Block.box(0.0D, 0.0D, 0.0D, 16.0D, 7.0D, 16.0D);
+
+        @Override
+        public VoxelShape getShape(BlockState state, BlockGetter worldIn, BlockPos pos, CollisionContext context) {
+                if (this.isDouble()) {
+                        return DOUBLE_SHAPE;
+                }
+                return state.getValue(HALF) == BlockSlab.EnumBlockHalf.TOP ? TOP_SHAPE : BOTTOM_SHAPE;
+        }
+
+        @Override
+        public VoxelShape getCollisionShape(BlockState state, BlockGetter worldIn, BlockPos pos, CollisionContext context) {
+                return getShape(state, worldIn, pos, context);
+        }
 	
     @Override
     public boolean doesSideBlockRendering(IBlockAccess world, BlockPos pos, EnumFacing face)
@@ -67,30 +85,6 @@ public class BlockMillPathSlab extends BlockSlab
         return (side == EnumBlockHalf.TOP && face == EnumFacing.DOWN) || (side == EnumBlockHalf.BOTTOM && face == EnumFacing.UP);
     }
 
-	@Override
-	public void setBlockBoundsBasedOnState(IBlockAccess worldIn, BlockPos pos)
-    {
-        if (this.isDouble())
-        {
-            this.setBlockBounds(0.0F, 0.0F, 0.0F, 1.0F, 0.9375F, 1.0F);
-        }
-        else
-        {
-            BlockState iblockstate = worldIn.getBlockState(pos);
-
-            if (iblockstate.getBlock() == this)
-            {
-                if (iblockstate.getValue(HALF) == BlockSlab.EnumBlockHalf.TOP)
-                {
-                    this.setBlockBounds(0.0F, 0.5F, 0.0F, 1.0F, 0.9375F, 1.0F);
-                }
-                else
-                {
-                    this.setBlockBounds(0.0F, 0.0F, 0.0F, 1.0F, 0.4375F, 1.0F);
-                }
-            }
-        }
-    }
 
     public String getUnlocalizedName(int meta)
     {

--- a/src/main/java/org/millenaire/blocks/BlockMillSign.java
+++ b/src/main/java/org/millenaire/blocks/BlockMillSign.java
@@ -9,6 +9,10 @@ import org.millenaire.items.ItemMillSign;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockWallSign;
 import net.minecraft.block.BlockState;
+import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.phys.shapes.VoxelShape;
+import net.minecraft.world.phys.shapes.CollisionContext;
+import net.minecraft.core.BlockPos;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.BlockModelShapes;
 import net.minecraft.client.renderer.BlockRendererDispatcher;
@@ -35,12 +39,19 @@ public class BlockMillSign extends BlockWallSign
 	@Override
 	public Item getItemDropped(BlockState state, Random rand, int fortune) { return null; }
 	
-	@Override
-	public boolean isOpaqueCube() { return false; }
-	
-	@Override
-	public int getRenderType() { return -1; }
+        @Override
+        public int getRenderType() { return -1; }
 
-	@Override
-	public TileEntity createNewTileEntity(World worldIn, int meta) { return new TileEntityMillSign(); }
+        @Override
+        public TileEntity createNewTileEntity(World worldIn, int meta) { return new TileEntityMillSign(); }
+
+        @Override
+        public VoxelShape getShape(BlockState state, BlockGetter worldIn, BlockPos pos, CollisionContext context) {
+                return super.getShape(state, worldIn, pos, context);
+        }
+
+        @Override
+        public VoxelShape getCollisionShape(BlockState state, BlockGetter worldIn, BlockPos pos, CollisionContext context) {
+                return super.getCollisionShape(state, worldIn, pos, context);
+        }
 }

--- a/src/main/java/org/millenaire/blocks/StoredPosition.java
+++ b/src/main/java/org/millenaire/blocks/StoredPosition.java
@@ -12,6 +12,10 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.util.EnumParticleTypes;
 import net.minecraft.util.IStringSerializable;
 import net.minecraft.world.World;
+import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.phys.shapes.VoxelShape;
+import net.minecraft.world.phys.shapes.CollisionContext;
+import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
@@ -27,11 +31,18 @@ public class StoredPosition extends Block
 	@Override
     public int getRenderType() { return -1; }
 
+    /** Voxel shape used when debug particles are visible. */
+    private static final VoxelShape SHAPE = Block.box(0.0D, 0.0D, 0.0D, 16.0D, 16.0D, 16.0D);
+
     @Override
-    public boolean isOpaqueCube() { return false; }
-    
+    public VoxelShape getShape(BlockState state, BlockGetter worldIn, BlockPos pos, CollisionContext context) {
+        return showParticles ? SHAPE : Shapes.empty();
+    }
+
     @Override
-    public boolean isFullCube() { return false; }
+    public VoxelShape getCollisionShape(BlockState state, BlockGetter worldIn, BlockPos pos, CollisionContext context) {
+        return Shapes.empty();
+    }
     
     @SideOnly(Side.CLIENT)
     public float getAmbientOcclusionLightValue() { return 1.0F; }


### PR DESCRIPTION
## Summary
- remove deprecated bounding box APIs from block classes
- implement `getShape` and `getCollisionShape` using `VoxelShape`

## Testing
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_6883e4f4e7f88330bc2a516d12e7311c