### PR TITLE
Update creative inventory method

### DIFF
--- a/src/main/java/org/millenaire/blocks/BlockDecorativeEarth.java
+++ b/src/main/java/org/millenaire/blocks/BlockDecorativeEarth.java
@@ -1,15 +1,15 @@
 package org.millenaire.blocks;
 
-import java.util.List;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.properties.IProperty;
 import net.minecraft.block.properties.PropertyEnum;
 import net.minecraft.block.BlockState;
-import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.core.NonNullList;
 import net.minecraft.util.IStringSerializable;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -25,15 +25,13 @@ public class BlockDecorativeEarth extends Block
 	
 	@Override
 	@SideOnly(Side.CLIENT)
-    public void getSubBlocks(Item itemIn, CreativeTabs tab, List list)
+    public void fillItemCategory(CreativeModeTab tab, NonNullList<ItemStack> list)
     {
-        if (Block.getBlockFromItem(itemIn) == this)
-        {
-            BlockDecorativeEarth.EnumType[] aenumtype = BlockDecorativeEarth.EnumType.values();
+        BlockDecorativeEarth.EnumType[] aenumtype = BlockDecorativeEarth.EnumType.values();
 
-            for (EnumType enumtype : aenumtype) {
-                list.add(new ItemStack(itemIn, 1, enumtype.getMetadata()));
-            }
+        Item itemIn = Item.getItemFromBlock(this);
+        for (EnumType enumtype : aenumtype) {
+            list.add(new ItemStack(itemIn, 1, enumtype.getMetadata()));
         }
     }
 

--- a/src/main/java/org/millenaire/blocks/BlockDecorativeSodPlank.java
+++ b/src/main/java/org/millenaire/blocks/BlockDecorativeSodPlank.java
@@ -1,6 +1,5 @@
 package org.millenaire.blocks;
 
-import java.util.List;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.SoundType;
@@ -8,9 +7,10 @@ import net.minecraft.block.material.Material;
 import net.minecraft.block.properties.IProperty;
 import net.minecraft.block.properties.PropertyEnum;
 import net.minecraft.block.BlockState;
-import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.core.NonNullList;
 import net.minecraft.util.IStringSerializable;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -32,15 +32,13 @@ public class BlockDecorativeSodPlank extends Block
 	
 	@Override
 	@SideOnly(Side.CLIENT)
-    public void getSubBlocks(Item itemIn, CreativeTabs tab, List list)
+    public void fillItemCategory(CreativeModeTab tab, NonNullList<ItemStack> list)
     {
-        if (Block.getBlockFromItem(itemIn) == this)
-        {
-            BlockDecorativeSodPlank.EnumType[] aenumtype = BlockDecorativeSodPlank.EnumType.values();
+        BlockDecorativeSodPlank.EnumType[] aenumtype = BlockDecorativeSodPlank.EnumType.values();
 
-            for (EnumType enumtype : aenumtype) {
-                list.add(new ItemStack(itemIn, 1, enumtype.getMetadata()));
-            }
+        Item itemIn = Item.getItemFromBlock(this);
+        for (EnumType enumtype : aenumtype) {
+            list.add(new ItemStack(itemIn, 1, enumtype.getMetadata()));
         }
     }
 

--- a/src/main/java/org/millenaire/blocks/BlockDecorativeStone.java
+++ b/src/main/java/org/millenaire/blocks/BlockDecorativeStone.java
@@ -1,15 +1,15 @@
 package org.millenaire.blocks;
 
-import java.util.List;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.properties.IProperty;
 import net.minecraft.block.properties.PropertyEnum;
 import net.minecraft.block.BlockState;
-import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.core.NonNullList;
 import net.minecraft.util.IStringSerializable;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -25,15 +25,13 @@ public class BlockDecorativeStone extends Block
 	
 	@Override
 	@SideOnly(Side.CLIENT)
-    public void getSubBlocks(Item itemIn, CreativeTabs tab, List list)
+    public void fillItemCategory(CreativeModeTab tab, NonNullList<ItemStack> list)
     {
-        if (Block.getBlockFromItem(itemIn) == this)
-        {
-            BlockDecorativeStone.EnumType[] aenumtype = BlockDecorativeStone.EnumType.values();
+        BlockDecorativeStone.EnumType[] aenumtype = BlockDecorativeStone.EnumType.values();
 
-            for (EnumType enumtype : aenumtype) {
-                list.add(new ItemStack(itemIn, 1, enumtype.getMetadata()));
-            }
+        Item itemIn = Item.getItemFromBlock(this);
+        for (EnumType enumtype : aenumtype) {
+            list.add(new ItemStack(itemIn, 1, enumtype.getMetadata()));
         }
     }
 

--- a/src/main/java/org/millenaire/blocks/BlockDecorativeWood.java
+++ b/src/main/java/org/millenaire/blocks/BlockDecorativeWood.java
@@ -1,15 +1,15 @@
 package org.millenaire.blocks;
 
-import java.util.List;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.properties.IProperty;
 import net.minecraft.block.properties.PropertyEnum;
 import net.minecraft.block.BlockState;
-import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.core.NonNullList;
 import net.minecraft.util.IStringSerializable;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -28,15 +28,13 @@ public class BlockDecorativeWood extends Block
 	
 	@Override
 	@SideOnly(Side.CLIENT)
-    public void getSubBlocks(Item itemIn, CreativeTabs tab, List list)
+    public void fillItemCategory(CreativeModeTab tab, NonNullList<ItemStack> list)
     {
-        if (Block.getBlockFromItem(itemIn) == this)
-        {
-            BlockDecorativeWood.EnumType[] aenumtype = BlockDecorativeWood.EnumType.values();
+        BlockDecorativeWood.EnumType[] aenumtype = BlockDecorativeWood.EnumType.values();
 
-            for (EnumType enumtype : aenumtype) {
-                list.add(new ItemStack(itemIn, 1, enumtype.getMetadata()));
-            }
+        Item itemIn = Item.getItemFromBlock(this);
+        for (EnumType enumtype : aenumtype) {
+            list.add(new ItemStack(itemIn, 1, enumtype.getMetadata()));
         }
     }
 

--- a/src/main/java/org/millenaire/blocks/BlockMillPath.java
+++ b/src/main/java/org/millenaire/blocks/BlockMillPath.java
@@ -1,6 +1,5 @@
 package org.millenaire.blocks;
 
-import java.util.List;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
@@ -11,9 +10,10 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import net.minecraft.world.phys.shapes.CollisionContext;
-import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.core.NonNullList;
 import net.minecraft.util.IStringSerializable;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -48,15 +48,13 @@ public class BlockMillPath extends Block
 	
 	@Override
 	@SideOnly(Side.CLIENT)
-    public void getSubBlocks(Item itemIn, CreativeTabs tab, List list)
+    public void fillItemCategory(CreativeModeTab tab, NonNullList<ItemStack> list)
     {
-        if (Block.getBlockFromItem(itemIn) == this)
-        {
-            BlockMillPath.EnumType[] aenumtype = BlockMillPath.EnumType.values();
+        BlockMillPath.EnumType[] aenumtype = BlockMillPath.EnumType.values();
 
-            for (EnumType enumtype : aenumtype) {
-                list.add(new ItemStack(itemIn, 1, enumtype.getMetadata()));
-            }
+        Item itemIn = Item.getItemFromBlock(this);
+        for (EnumType enumtype : aenumtype) {
+            list.add(new ItemStack(itemIn, 1, enumtype.getMetadata()));
         }
     }
 

--- a/src/main/java/org/millenaire/blocks/BlockMillPathSlab.java
+++ b/src/main/java/org/millenaire/blocks/BlockMillPathSlab.java
@@ -1,6 +1,5 @@
 package org.millenaire.blocks;
 
-import java.util.List;
 import java.util.Random;
 
 import net.minecraft.block.BlockSlab;
@@ -9,9 +8,10 @@ import net.minecraft.block.properties.IProperty;
 import net.minecraft.block.properties.PropertyBool;
 import net.minecraft.block.properties.PropertyEnum;
 import net.minecraft.block.BlockState;
-import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.core.NonNullList;
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.world.IBlockAccess;
@@ -101,8 +101,9 @@ public class BlockMillPathSlab extends BlockSlab
     }
 
     @SideOnly(Side.CLIENT)
-    public void getSubBlocks(Item itemIn, CreativeTabs tab, List list)
+    public void fillItemCategory(CreativeModeTab tab, NonNullList<ItemStack> list)
     {
+        Item itemIn = Item.getItemFromBlock(this);
         if (itemIn != Item.getItemFromBlock(MillBlocks.blockMillPathSlabDouble))
         {
             BlockMillPath.EnumType[] aenumtype = BlockMillPath.EnumType.values();

--- a/src/main/java/org/millenaire/building/BuildingPlan.java
+++ b/src/main/java/org/millenaire/building/BuildingPlan.java
@@ -24,7 +24,7 @@ import net.minecraft.block.BlockStoneSlab;
 import net.minecraft.block.BlockWoodSlab;
 import net.minecraft.block.properties.IProperty;
 import net.minecraft.block.BlockState;
-import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
@@ -1006,7 +1006,7 @@ public class BuildingPlan
 	}
 	
 	private boolean firstPass(BlockState state) {
-		return state.getBlock().getCreativeTabToDisplayOn() == CreativeTabs.tabBlock || state.getBlock() instanceof BlockDecorativeEarth || state.getBlock() instanceof BlockDecorativeWood || state.getBlock() instanceof BlockDecorativeStone || state.getBlock() == MillBlocks.byzantineStoneTile || state.getBlock() == MillBlocks.byzantineTile || state.getBlock() == MillBlocks.byzantineTileSlab || state.getBlock() == MillBlocks.byzantineTileSlabDouble;
+               return state.getBlock().getCreativeTabToDisplayOn() == CreativeModeTab.TAB_BUILDING_BLOCKS || state.getBlock() instanceof BlockDecorativeEarth || state.getBlock() instanceof BlockDecorativeWood || state.getBlock() instanceof BlockDecorativeStone || state.getBlock() == MillBlocks.byzantineStoneTile || state.getBlock() == MillBlocks.byzantineTile || state.getBlock() == MillBlocks.byzantineTileSlab || state.getBlock() == MillBlocks.byzantineTileSlabDouble;
 	}
 	
 	private void setReferencePositions(BlockState state, BlockPos pos, BuildingLocation location)


### PR DESCRIPTION
## Summary
- remove legacy CreativeTabs usage
- migrate blocks from `getSubBlocks` to `fillItemCategory`
- use `CreativeModeTab` and `NonNullList`

## Testing
- `gradle test` *(fails: Found Gradle version Gradle 8.14.3. Versions Gradle 6.0.0 and newer are not supported in FG3)*

------
https://chatgpt.com/codex/tasks/task_e_6883e7efe3c083308d5c18a10ea2398d