### PR TITLE
Replace EnumHelper usage with custom armor and tool tiers

### DIFF
--- a/src/main/java/org/millenaire/items/ItemMillArmor.java
+++ b/src/main/java/org/millenaire/items/ItemMillArmor.java
@@ -5,26 +5,25 @@ import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.Entity;
 import net.minecraft.item.ItemArmor;
 import net.minecraft.item.ItemStack;
-import net.minecraft.item.ItemArmor.ArmorMaterial;
+import net.minecraft.item.IArmorMaterial;
 import net.minecraft.world.World;
-import net.minecraftforge.common.util.EnumHelper;
 
 public class ItemMillArmor 
 {
-	static ArmorMaterial ARMOR_norman = EnumHelper.addArmorMaterial("normanArmour", "millenaire:normanArmor", 66, new int[] { 3, 8, 6, 3 }, 10);
-	static ArmorMaterial ARMOR_japaneseWarriorRed = EnumHelper.addArmorMaterial("japaneseWarriorRed", "millenaire:japaneseWarriorArmorRed", 33, new int[] { 2, 6, 5, 2 }, 25);
-	static ArmorMaterial ARMOR_japaneseWarriorBlue = EnumHelper.addArmorMaterial("japaneseWarriorBlue", "millenaire:japaneseWarriorArmorBlue", 33, new int[] { 2, 6, 5, 2 }, 25);
-	static ArmorMaterial ARMOR_japaneseGuard = EnumHelper.addArmorMaterial("japaneseGuard", "millenaire:japaneseGuardArmor", 25, new int[] { 2, 5, 4, 1 }, 25);
-	static ArmorMaterial ARMOR_byzantine = EnumHelper.addArmorMaterial("byzantineArmour", "millenaire:byzantineArmor", 33, new int[] { 3, 8, 6, 3 }, 20);
-	static ArmorMaterial ARMOR_mayanQuest = EnumHelper.addArmorMaterial("mayanQuest", "millenaire:mayanQuest", 5, new int[]{1, 3, 2, 1}, 35);
+    static IArmorMaterial ARMOR_norman = MillArmorMaterial.NORMAN;
+    static IArmorMaterial ARMOR_japaneseWarriorRed = MillArmorMaterial.JAPANESE_WARRIOR_RED;
+    static IArmorMaterial ARMOR_japaneseWarriorBlue = MillArmorMaterial.JAPANESE_WARRIOR_BLUE;
+    static IArmorMaterial ARMOR_japaneseGuard = MillArmorMaterial.JAPANESE_GUARD;
+    static IArmorMaterial ARMOR_byzantine = MillArmorMaterial.BYZANTINE;
+    static IArmorMaterial ARMOR_mayanQuest = MillArmorMaterial.MAYAN_QUEST;
 	
-	public static class mayanQuestCrown extends ItemArmor
-	{
+        public static class mayanQuestCrown extends ItemArmor
+        {
 
-		public mayanQuestCrown(ArmorMaterial material, int renderIndex, int armorType) 
-		{
-			super(material, renderIndex, armorType);
-		}
+                public mayanQuestCrown(IArmorMaterial material, int renderIndex, int armorType)
+                {
+                        super(material, renderIndex, armorType);
+                }
 		
 		@Override
 		public void onUpdate(ItemStack stack, World worldIn, Entity entityIn, int itemSlot, boolean isSelected)

--- a/src/main/java/org/millenaire/items/ItemMillTool.java
+++ b/src/main/java/org/millenaire/items/ItemMillTool.java
@@ -3,7 +3,7 @@ package org.millenaire.items;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.Entity;
-import net.minecraft.item.Item.ToolMaterial;
+import net.minecraft.item.IItemTier;
 import net.minecraft.item.ItemAxe;
 import net.minecraft.item.ItemHoe;
 import net.minecraft.item.ItemPickaxe;
@@ -11,36 +11,35 @@ import net.minecraft.item.ItemSpade;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.ItemSword;
 import net.minecraft.world.World;
-import net.minecraftforge.common.util.EnumHelper;
 
 public class ItemMillTool 
 {
-	static ToolMaterial TOOLS_norman = EnumHelper.addToolMaterial("normanTools", 2, 1561, 10.0F, 4.0F, 10);
-	static ToolMaterial TOOLS_obsidian = EnumHelper.addToolMaterial("obsidianTools", 3, 1561, 6.0F, 2.0F, 25);
+    static IItemTier TOOLS_norman = MillItemTier.NORMAN;
+    static IItemTier TOOLS_obsidian = MillItemTier.OBSIDIAN;
 
-	static class ItemMillAxe extends ItemAxe
-	{
-		ItemMillAxe(ToolMaterial material) { super(material); }
-	}
+        static class ItemMillAxe extends ItemAxe
+        {
+                ItemMillAxe(IItemTier material) { super(material); }
+        }
 
-	static class ItemMillShovel extends ItemSpade
-	{
-		ItemMillShovel(ToolMaterial material) { super(material); }
-	}
+        static class ItemMillShovel extends ItemSpade
+        {
+                ItemMillShovel(IItemTier material) { super(material); }
+        }
 
-	static class ItemMillPickaxe extends ItemPickaxe
-	{
-		ItemMillPickaxe(ToolMaterial material) { super(material); }
-	}
+        static class ItemMillPickaxe extends ItemPickaxe
+        {
+                ItemMillPickaxe(IItemTier material) { super(material); }
+        }
 
-	static class ItemMillHoe extends ItemHoe
-	{
-		ItemMillHoe(ToolMaterial material) { super(material); }
-	}
+        static class ItemMillHoe extends ItemHoe
+        {
+                ItemMillHoe(IItemTier material) { super(material); }
+        }
 	
-	public static class ItemMillMace extends ItemSword
-	{
-		ItemMillMace(ToolMaterial material) { super(material); }
+        public static class ItemMillMace extends ItemSword
+        {
+                ItemMillMace(IItemTier material) { super(material); }
 		
 		@Override
 		public void onUpdate(ItemStack stack, World worldIn, Entity entityIn, int itemSlot, boolean isSelected)

--- a/src/main/java/org/millenaire/items/MillArmorMaterial.java
+++ b/src/main/java/org/millenaire/items/MillArmorMaterial.java
@@ -1,0 +1,65 @@
+package org.millenaire.items;
+
+import net.minecraft.item.IArmorMaterial;
+import net.minecraft.item.crafting.Ingredient;
+import net.minecraft.util.SoundEvent;
+import net.minecraft.util.SoundEvents;
+import net.minecraft.inventory.EquipmentSlotType;
+
+public enum MillArmorMaterial implements IArmorMaterial {
+    NORMAN("millenaire:normanArmor", 66, new int[]{3,8,6,3}, 10),
+    JAPANESE_WARRIOR_RED("millenaire:japaneseWarriorArmorRed", 33, new int[]{2,6,5,2}, 25),
+    JAPANESE_WARRIOR_BLUE("millenaire:japaneseWarriorArmorBlue", 33, new int[]{2,6,5,2}, 25),
+    JAPANESE_GUARD("millenaire:japaneseGuardArmor", 25, new int[]{2,5,4,1}, 25),
+    BYZANTINE("millenaire:byzantineArmor", 33, new int[]{3,8,6,3}, 20),
+    MAYAN_QUEST("millenaire:mayanQuest", 5, new int[]{1,3,2,1}, 35);
+
+    private static final int[] BASE_DURABILITY = new int[]{13, 15, 16, 11};
+
+    private final String name;
+    private final int durabilityFactor;
+    private final int[] damageReduction;
+    private final int enchantability;
+
+    MillArmorMaterial(String name, int durabilityFactor, int[] damageReduction, int enchantability) {
+        this.name = name;
+        this.durabilityFactor = durabilityFactor;
+        this.damageReduction = damageReduction;
+        this.enchantability = enchantability;
+    }
+
+    @Override
+    public int getDurability(EquipmentSlotType slot) {
+        return BASE_DURABILITY[slot.getIndex()] * this.durabilityFactor;
+    }
+
+    @Override
+    public int getDamageReductionAmount(EquipmentSlotType slot) {
+        return this.damageReduction[slot.getIndex()];
+    }
+
+    @Override
+    public int getEnchantability() {
+        return this.enchantability;
+    }
+
+    @Override
+    public SoundEvent getSoundEvent() {
+        return SoundEvents.ITEM_ARMOR_EQUIP_GENERIC;
+    }
+
+    @Override
+    public Ingredient getRepairMaterial() {
+        return Ingredient.EMPTY;
+    }
+
+    @Override
+    public String getName() {
+        return this.name;
+    }
+
+    @Override
+    public float getToughness() {
+        return 0.0F;
+    }
+}

--- a/src/main/java/org/millenaire/items/MillItemTier.java
+++ b/src/main/java/org/millenaire/items/MillItemTier.java
@@ -1,0 +1,53 @@
+package org.millenaire.items;
+
+import net.minecraft.item.IItemTier;
+import net.minecraft.item.crafting.Ingredient;
+
+public enum MillItemTier implements IItemTier {
+    NORMAN(2, 1561, 10.0F, 4.0F, 10),
+    OBSIDIAN(3, 1561, 6.0F, 2.0F, 25);
+
+    private final int harvestLevel;
+    private final int maxUses;
+    private final float efficiency;
+    private final float attackDamage;
+    private final int enchantability;
+
+    MillItemTier(int harvestLevel, int maxUses, float efficiency, float attackDamage, int enchantability) {
+        this.harvestLevel = harvestLevel;
+        this.maxUses = maxUses;
+        this.efficiency = efficiency;
+        this.attackDamage = attackDamage;
+        this.enchantability = enchantability;
+    }
+
+    @Override
+    public int getMaxUses() {
+        return maxUses;
+    }
+
+    @Override
+    public float getEfficiency() {
+        return efficiency;
+    }
+
+    @Override
+    public float getAttackDamage() {
+        return attackDamage;
+    }
+
+    @Override
+    public int getHarvestLevel() {
+        return harvestLevel;
+    }
+
+    @Override
+    public int getEnchantability() {
+        return enchantability;
+    }
+
+    @Override
+    public Ingredient getRepairMaterial() {
+        return Ingredient.EMPTY;
+    }
+}

--- a/src/main/java/org/millenaire/items/MillItems.java
+++ b/src/main/java/org/millenaire/items/MillItems.java
@@ -18,6 +18,7 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemArmor;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.ItemSword;
+import net.minecraft.item.ItemTier;
 import net.minecraft.potion.Potion;
 import net.minecraftforge.common.IPlantable;
 import net.minecraftforge.api.distmarker.Dist;
@@ -319,10 +320,10 @@ public class MillItems
 		mayanMace = new ItemSword(ItemMillTool.TOOLS_obsidian);
 		ITEMS.register("mayan_mace", () -> mayanMace);
 		
-		byzantineMace = new ItemMillMace(Item.ToolMaterial.IRON);
+                byzantineMace = new ItemMillMace(ItemTier.IRON);
 		ITEMS.register("byzantine_mace", () -> byzantineMace);
 		
-		japaneseSword = new ItemSword(Item.ToolMaterial.IRON);
+                japaneseSword = new ItemSword(ItemTier.IRON);
 		ITEMS.register("japanese_sword", () -> japaneseSword);
 		japaneseBow = new ItemMillBow(2, 0.5F, "japanese_bow");
 		ITEMS.register("japanese_bow", () -> japaneseBow);


### PR DESCRIPTION
## Summary
- add `MillArmorMaterial` and `MillItemTier` enums implementing `IArmorMaterial`/`IItemTier`
- remove `EnumHelper` and use the new enums when creating items

## Testing
- `gradle` build not configured; no tests run

------
https://chatgpt.com/codex/tasks/task_e_6883ec90e7d88330a4104e2182a3995e