### PR TITLE
Fix item stack handling

### DIFF
--- a/src/main/java/org/millenaire/CommonUtilities.java
+++ b/src/main/java/org/millenaire/CommonUtilities.java
@@ -20,54 +20,54 @@ public class CommonUtilities
 	 */
 	public static void changeMoney(Player playerIn)
 	{
-		ItemStack denier = new ItemStack(MillItems.denier, 0, 0);
-		ItemStack argent = new ItemStack(MillItems.denierArgent, 0, 0);
-		ItemStack or = new ItemStack(MillItems.denierOr, 0, 0);
+                ItemStack denier = new ItemStack(MillItems.denier, 0, 0);
+                ItemStack argent = new ItemStack(MillItems.denierArgent, 0, 0);
+                ItemStack or = new ItemStack(MillItems.denierOr, 0, 0);
 		
 		for(int i = 0; i < playerIn.getInventory().getSizeInventory(); i++)
 		{
-			ItemStack stack = playerIn.getInventory().getStackInSlot(i);
-			if(stack != null)
-			{
-				if(stack.getItem() == MillItems.denier)
-				{
-					denier.stackSize = denier.stackSize + stack.stackSize;
-					playerIn.getInventory().removeStackFromSlot(i);
-				}
-				if(stack.getItem() == MillItems.denierArgent)
-				{
-					argent.stackSize = argent.stackSize + stack.stackSize;
-					playerIn.getInventory().removeStackFromSlot(i);
-				}
-				if(stack.getItem() == MillItems.denierOr)
-				{
-					or.stackSize = or.stackSize + stack.stackSize;
-					playerIn.getInventory().removeStackFromSlot(i);
-				}
-			}
-		}
-		
-		argent.stackSize = argent.stackSize + (denier.stackSize / 64);
-		denier.stackSize = denier.stackSize % 64;
-		
-		or.stackSize = or.stackSize + (argent.stackSize / 64);
-		if(or.stackSize >= 1)
-		{
-			playerIn.addStat(MillAchievement.cresus, 1);
-		}
+                        ItemStack stack = playerIn.getInventory().getStackInSlot(i);
+                        if(stack != null)
+                        {
+                                if(stack.getItem() == MillItems.denier)
+                                {
+                                        denier.grow(stack.getCount());
+                                        playerIn.getInventory().removeStackFromSlot(i);
+                                }
+                                if(stack.getItem() == MillItems.denierArgent)
+                                {
+                                        argent.grow(stack.getCount());
+                                        playerIn.getInventory().removeStackFromSlot(i);
+                                }
+                                if(stack.getItem() == MillItems.denierOr)
+                                {
+                                        or.grow(stack.getCount());
+                                        playerIn.getInventory().removeStackFromSlot(i);
+                                }
+                        }
+                }
 
-		argent.stackSize = argent.stackSize % 64;
-		
-		playerIn.getInventory().addItemStackToInventory(denier);
-		playerIn.getInventory().addItemStackToInventory(argent);
-		
-		while(or.stackSize > 64)
-		{
-			playerIn.getInventory().addItemStackToInventory(new ItemStack(MillItems.denierOr, 64, 0));
-			or.stackSize = or.stackSize - 64;
-		}
+                argent.grow(denier.getCount() / 64);
+                denier.setCount(denier.getCount() % 64);
 
-		playerIn.getInventory().addItemStackToInventory(or);
+                or.grow(argent.getCount() / 64);
+                if(or.getCount() >= 1)
+                {
+                        playerIn.addStat(MillAchievement.cresus, 1);
+                }
+
+                argent.setCount(argent.getCount() % 64);
+
+                playerIn.getInventory().addItemStackToInventory(denier);
+                playerIn.getInventory().addItemStackToInventory(argent);
+
+                while(or.getCount() > 64)
+                {
+                        playerIn.getInventory().addItemStackToInventory(new ItemStack(MillItems.denierOr, 64, 0));
+                        or.shrink(64);
+                }
+
+                playerIn.getInventory().addItemStackToInventory(or);
 	}
 	
 	/**

--- a/src/main/java/org/millenaire/items/ItemMillAmulet.java
+++ b/src/main/java/org/millenaire/items/ItemMillAmulet.java
@@ -13,6 +13,8 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.World;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResultHolder;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 
@@ -28,12 +30,13 @@ public class ItemMillAmulet extends Item
 
 	}
 
-	@Override
-	public ItemStack onItemRightClick(final ItemStack itemstack, final World world, final Player entityplayer) 
-	{
-		if(this == MillItems.amuletSkollHati && !world.isRemote)
-		{
-			final long time = world.getWorldTime() + 24000L;
+        @Override
+        public InteractionResultHolder<ItemStack> use(final World world, final Player entityplayer, InteractionHand hand)
+        {
+                ItemStack itemstack = entityplayer.getItemInHand(hand);
+                if(this == MillItems.amuletSkollHati && !world.isRemote)
+                {
+                        final long time = world.getWorldTime() + 24000L;
 
 			if (time % 24000L > 11000L && time % 24000L < 23500L) 
 			{
@@ -47,8 +50,8 @@ public class ItemMillAmulet extends Item
 			itemstack.damageItem(1, entityplayer);
 		}
 
-		return itemstack;
-	}
+                return InteractionResultHolder.success(itemstack);
+        }
 
 	@Override
 	public void onUpdate(ItemStack stack, World worldIn, Entity entityIn, int itemSlot, boolean isSelected)

--- a/src/main/java/org/millenaire/items/ItemMillParchment.java
+++ b/src/main/java/org/millenaire/items/ItemMillParchment.java
@@ -11,6 +11,8 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.MenuProvider;
 import net.minecraft.network.chat.TextComponent;
 import net.minecraft.world.SimpleMenuProvider;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResultHolder;
 import org.millenaire.gui.EmptyMenu;
 import org.millenaire.gui.MillMenus;
 
@@ -25,15 +27,16 @@ public class ItemMillParchment extends ItemWritableBook
 		contents = contentIn;
 	}
 	
-	@Override
-        public ItemStack onItemRightClick(ItemStack itemStackIn, Level worldIn, Player playerIn)
+        @Override
+        public InteractionResultHolder<ItemStack> use(Level worldIn, Player playerIn, InteractionHand hand)
     {
+                ItemStack itemStackIn = playerIn.getItemInHand(hand);
                 if(worldIn.isRemote)
                 {
                         MenuProvider provider = new SimpleMenuProvider((id, inv, player) -> new EmptyMenu(MillMenus.PARCHMENT_MENU.get(), id), new TextComponent("Parchment"));
                         NetworkHooks.openGui((ServerPlayer)playerIn, provider);
                 }
-		
-        return itemStackIn;
+
+        return InteractionResultHolder.success(itemStackIn);
     }
 }

--- a/src/main/java/org/millenaire/items/ItemMillSeeds.java
+++ b/src/main/java/org/millenaire/items/ItemMillSeeds.java
@@ -8,8 +8,9 @@ import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemSeeds;
 import net.minecraft.item.ItemStack;
 import net.minecraft.core.BlockPos;
-import net.minecraft.util.EnumFacing;
 import net.minecraft.world.World;
+import net.minecraft.world.item.context.UseOnContext;
+import net.minecraft.world.InteractionResult;
 
 public class ItemMillSeeds extends ItemSeeds
 {
@@ -19,8 +20,13 @@ public class ItemMillSeeds extends ItemSeeds
 		super(crops, Blocks.farmland);
 	}
 
-	@Override
-	public boolean onItemUse(ItemStack stack, Player playerIn, World worldIn, BlockPos pos, EnumFacing side, float hitX, float hitY, float hitZ) {
-		return !worldIn.isRemote && PlayerTracker.get(playerIn).canPlayerUseCrop(stack.getItem()) && super.onItemUse(stack, playerIn, worldIn, pos, side, hitX, hitY, hitZ);
-	}
+        @Override
+        public InteractionResult useOn(UseOnContext context) {
+                Player playerIn = context.getPlayer();
+                World worldIn = context.getLevel();
+                if(playerIn != null && !worldIn.isRemote && PlayerTracker.get(playerIn).canPlayerUseCrop(context.getItemInHand().getItem())) {
+                        return super.useOn(context);
+                }
+                return InteractionResult.FAIL;
+        }
 }

--- a/src/main/java/org/millenaire/items/ItemMillSign.java
+++ b/src/main/java/org/millenaire/items/ItemMillSign.java
@@ -9,8 +9,10 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.core.BlockPos;
-import net.minecraft.util.EnumFacing;
+import net.minecraft.core.Direction;
 import net.minecraft.world.World;
+import net.minecraft.world.item.context.UseOnContext;
+import net.minecraft.world.InteractionResult;
 
 public class ItemMillSign extends Item
 {
@@ -19,38 +21,43 @@ public class ItemMillSign extends Item
 	/**
 	 * Called when a Block is right-clicked with this Item
 	 */
-	public boolean onItemUse(ItemStack stack, Player playerIn, World worldIn, BlockPos pos, EnumFacing side, float hitX, float hitY, float hitZ)
-	{
-		if (side == EnumFacing.DOWN)
-		{
-			return false;
-		}
-		else if (!worldIn.getBlockState(pos).getBlock().getMaterial().isSolid())
-		{
-			return false;
-		}
-		else
-		{
-			pos = pos.offset(side);
+        public InteractionResult useOn(UseOnContext context)
+        {
+                ItemStack stack = context.getItemInHand();
+                Player playerIn = context.getPlayer();
+                World worldIn = context.getLevel();
+                BlockPos pos = context.getClickedPos();
+                Direction side = context.getClickedFace();
 
-			if (!playerIn.mayUseItemAt(pos, side, stack))
-			{
-				return false;
-			}
-			else if (worldIn.isRemote)
-			{
-				return true;
-			}
-			else
-			{
-                                worldIn.setBlockState(pos, MillBlocks.blockMillSign.getDefaultState().withProperty(BlockMillSign.FACING, side)/*Blocks.wall_sign.getDefaultState().withProperty(BlockWallSign.FACING, side)*/, 3);
+                if (side == Direction.DOWN)
+                {
+                        return InteractionResult.FAIL;
+                }
+                else if (!worldIn.getBlockState(pos).getBlock().getMaterial().isSolid())
+                {
+                        return InteractionResult.FAIL;
+                }
+                else
+                {
+                        pos = pos.offset(side);
 
+                        if (playerIn == null || !playerIn.mayUseItemAt(pos, side, stack))
+                        {
+                                return InteractionResult.FAIL;
+                        }
+                        else if (worldIn.isRemote)
+                        {
+                                return InteractionResult.SUCCESS;
+                        }
+                        else
+                        {
+                                worldIn.setBlockState(pos, MillBlocks.blockMillSign.getDefaultState().withProperty(BlockMillSign.FACING, side), 3);
 
-				--stack.stackSize;
-				TileEntity tileentity = worldIn.getTileEntity(pos);
+                                stack.shrink(1);
+                                TileEntity tileentity = worldIn.getTileEntity(pos);
 
-				return true;
-			}
-		}
-	}
+                                return InteractionResult.SUCCESS;
+                        }
+                }
+        }
 }

--- a/src/main/java/org/millenaire/items/ItemMillWallet.java
+++ b/src/main/java/org/millenaire/items/ItemMillWallet.java
@@ -11,24 +11,27 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.world.World;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResultHolder;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 
 public class ItemMillWallet extends Item
 {
-	@Override
-	public ItemStack onItemRightClick(ItemStack itemStackIn, World worldIn, Player playerIn)
+        @Override
+public InteractionResultHolder<ItemStack> use(World worldIn, Player playerIn, InteractionHand hand)
     {
-		if(playerIn.getInventory().hasItem(MillItems.denier) || playerIn.getInventory().hasItem(MillItems.denierArgent) || playerIn.getInventory().hasItem(MillItems.denierOr))
-		{
-			addDenierToWallet(itemStackIn, playerIn);
-		}
-		else
-		{
-			emptyWallet(itemStackIn, playerIn);
-		}
-		
-        return itemStackIn;
+                ItemStack itemStackIn = playerIn.getItemInHand(hand);
+                if(playerIn.getInventory().hasItem(MillItems.denier) || playerIn.getInventory().hasItem(MillItems.denierArgent) || playerIn.getInventory().hasItem(MillItems.denierOr))
+                {
+                        addDenierToWallet(itemStackIn, playerIn);
+                }
+                else
+                {
+                        emptyWallet(itemStackIn, playerIn);
+                }
+
+        return InteractionResultHolder.success(itemStackIn);
     }
 	
 	@Override
@@ -73,27 +76,28 @@ public class ItemMillWallet extends Item
 			int argent = 0;
 			int or = 0;
 			
-			for(int i = 0; i < playerIn.getInventory().getSizeInventory(); i++)
-			{
-				if(playerIn.getInventory().getStackInSlot(i) != null)
-				{
-					if(playerIn.getInventory().getStackInSlot(i).getItem() == MillItems.denier)
-					{
-						denier += playerIn.getInventory().getStackInSlot(i).stackSize;
-						playerIn.getInventory().removeStackFromSlot(i);
-					}
-					else if(playerIn.getInventory().getStackInSlot(i).getItem() == MillItems.denierArgent)
-					{
-						argent += playerIn.getInventory().getStackInSlot(i).stackSize;
-						playerIn.getInventory().removeStackFromSlot(i);
-					}
-					else if(playerIn.getInventory().getStackInSlot(i).getItem() == MillItems.denierOr)
-					{
-						or += playerIn.getInventory().getStackInSlot(i).stackSize;
-						playerIn.getInventory().removeStackFromSlot(i);
-					}
-				}
-			}
+                        for(int i = 0; i < playerIn.getInventory().getSizeInventory(); i++)
+                        {
+                                if(playerIn.getInventory().getStackInSlot(i) != null)
+                                {
+                                        ItemStack invStack = playerIn.getInventory().getStackInSlot(i);
+                                        if(invStack.getItem() == MillItems.denier)
+                                        {
+                                                denier += invStack.getCount();
+                                                playerIn.getInventory().removeStackFromSlot(i);
+                                        }
+                                        else if(invStack.getItem() == MillItems.denierArgent)
+                                        {
+                                                argent += invStack.getCount();
+                                                playerIn.getInventory().removeStackFromSlot(i);
+                                        }
+                                        else if(invStack.getItem() == MillItems.denierOr)
+                                        {
+                                                or += invStack.getCount();
+                                                playerIn.getInventory().removeStackFromSlot(i);
+                                        }
+                                }
+                        }
 			
 			NBTTagCompound nbt;
 			

--- a/src/main/java/org/millenaire/items/ItemMillWand.java
+++ b/src/main/java/org/millenaire/items/ItemMillWand.java
@@ -28,6 +28,8 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.core.Direction;
 import net.minecraft.world.World;
+import net.minecraft.world.item.context.UseOnContext;
+import net.minecraft.world.InteractionResult;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 
@@ -48,12 +50,20 @@ public class ItemMillWand extends Item
                         Millenaire.channel.sendToServer(packet);
 			return true;
 		}
-		return false;
-	}
+                return InteractionResult.PASS;
+        }
 
-	@Override
-        public boolean onItemUse(ItemStack stack, Player playerIn, World worldIn, BlockPos pos, Direction side, float hitX, float hitY, float hitZ)
-	{
+        @Override
+        public InteractionResult useOn(UseOnContext context)
+        {
+                ItemStack stack = context.getItemInHand();
+                Player playerIn = context.getPlayer();
+                World worldIn = context.getLevel();
+                BlockPos pos = context.getClickedPos();
+                Direction side = context.getClickedFace();
+                float hitX = (float)context.getClickLocation().x;
+                float hitY = (float)context.getClickLocation().y;
+                float hitZ = (float)context.getClickLocation().z;
 		if(this == MillItems.wandNegation)
 		{
 			if(worldIn.getBlockState(pos).getBlock() == MillBlocks.villageStone)
@@ -263,8 +273,8 @@ public class ItemMillWand extends Item
                         playerIn.sendSystemMessage(Component.literal(output));
 		}
 
-		return false;
-	}
+                return InteractionResult.PASS;
+        }
 
 	@Override
 	public boolean itemInteractionForEntity(ItemStack stack, net.minecraft.world.entity.player.Player player, EntityLivingBase entity)


### PR DESCRIPTION
## Summary
- replace direct stackSize usage with getCount/grow/shrink
- migrate onItemRightClick/onItemUse to use/useOn signatures
- update wallet and wand logic for new APIs

## Testing
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_6883ede5c7048330b41b922d5c1b31c6