### PR TITLE
Update GUI methods for modern Forge

### DIFF
--- a/src/main/java/org/millenaire/gui/GuiChief.java
+++ b/src/main/java/org/millenaire/gui/GuiChief.java
@@ -18,26 +18,28 @@ public class GuiChief extends Screen
         private Button backward;
 	
 	@Override
-	public void drawScreen(int mouseX, int mouseY, float partialTicks) 
+	public void render(com.mojang.blaze3d.vertex.PoseStack poseStack, int mouseX, int mouseY, float partialTicks) 
 	{
-	    this.drawDefaultBackground();
-	    mc.getTextureManager().bindTexture(CHIEFGUI);
-	    this.drawTexturedModalRect((this.width - 255) / 2, 2, 0, 0, 255, 199);
-	    this.fontRendererObj.drawSplitString(string, (this.width / 2) - 94, 20, 190, 0);
+	    this.renderBackground(poseStack);
+	    Minecraft.getInstance().getTextureManager().bind(CHIEFGUI);
+	    this.blit(poseStack, (this.width - 255) / 2, 2, 0, 0, 255, 199);
+	    this.font.drawWordWrap(Component.literal(string), (this.width / 2) - 94, 20, 190, 0);
 	    
-	    super.drawScreen(mouseX, mouseY, partialTicks);
+	    super.render(poseStack, mouseX, mouseY, partialTicks);
 	}
 	
 	@Override
-	public void initGui() 
-	{
-            this.buttonList.add(this.backward = new NextPageButton(0, (this.width / 2) - 95, 208, false));
-            this.buttonList.add(this.forward = new NextPageButton(1, (this.width / 2) + 77, 208, true));
-	    updateButtons();
-	}
+        public void init()
+        {
+            this.backward = new NextPageButton(0, (this.width / 2) - 95, 208, false);
+            this.forward = new NextPageButton(1, (this.width / 2) + 77, 208, true);
+            this.addRenderableWidget(this.backward);
+            this.addRenderableWidget(this.forward);
+            updateButtons();
+        }
 	
 	@Override
-        protected void actionPerformed(Button button)
+        protected void onPress(Button button)
 	{
 	    if (button == this.forward) 
 	    {

--- a/src/main/java/org/millenaire/gui/GuiMillChest.java
+++ b/src/main/java/org/millenaire/gui/GuiMillChest.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 
 import org.millenaire.entities.TileEntityMillChest;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.inventory.ChestScreen;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.ChestMenu;
@@ -53,9 +54,9 @@ public class GuiMillChest extends ChestScreen
 		}
 		else 
 		{
-			if (par2 == 1 || par2 == this.mc.gameSettings.keyBindInventory.getKeyCode()) 
+			if (par2 == 1 || par2 == Minecraft.getInstance().gameSettings.keyBindInventory.getKeyCode()) 
 			{
-				this.mc.thePlayer.closeScreen();
+				Minecraft.getInstance().thePlayer.closeScreen();
 			}
 		}
 	}

--- a/src/main/java/org/millenaire/gui/GuiOptions.java
+++ b/src/main/java/org/millenaire/gui/GuiOptions.java
@@ -25,24 +25,26 @@ public class GuiOptions extends Screen
 	}
 	
 	@Override
-	public void drawScreen(int mouseX, int mouseY, float partialTicks) 
+	public void render(com.mojang.blaze3d.vertex.PoseStack poseStack, int mouseX, int mouseY, float partialTicks) 
 	{
-	    this.drawDefaultBackground();
-	    mc.getTextureManager().bindTexture(OPTIONGUI);
-	    this.drawTexturedModalRect((this.width - 255) / 2, 2, 0, 0, 255, 199);
-	    this.fontRendererObj.drawSplitString(string, (this.width / 2) - 94, 20, 190, 0);
+	    this.renderBackground(poseStack);
+	    Minecraft.getInstance().getTextureManager().bind(OPTIONGUI);
+	    this.blit(poseStack, (this.width - 255) / 2, 2, 0, 0, 255, 199);
+	    this.font.drawWordWrap(Component.literal(string), (this.width / 2) - 94, 20, 190, 0);
 	    
-	    super.drawScreen(mouseX, mouseY, partialTicks);
+	    super.render(poseStack, mouseX, mouseY, partialTicks);
 	}
 	
-	public void initGui() 
-	{
-            this.buttonList.add(this.yes = new Button((this.width / 2) - 50, (this.height / 2) + 40, 40, 20, Component.literal("Yes"), b -> {}));
-            this.buttonList.add(this.no = new Button((this.width / 2) + 10, (this.height / 2) + 40, 40, 20, Component.literal("No"), b -> {}));
-	}
+        public void init()
+        {
+            this.yes = new Button((this.width / 2) - 50, (this.height / 2) + 40, 40, 20, Component.literal("Yes"), b -> {});
+            this.no = new Button((this.width / 2) + 10, (this.height / 2) + 40, 40, 20, Component.literal("No"), b -> {});
+            this.addRenderableWidget(this.yes);
+            this.addRenderableWidget(this.no);
+        }
 	
 	@Override
-        protected void actionPerformed(Button button)
+        protected void onPress(Button button)
 	{
 		if(button == this.yes)
 		{
@@ -58,15 +60,15 @@ public class GuiOptions extends Screen
 			{
                                 Millenaire.channel.sendToServer(new MillPacket(4));
 			}
-			this.mc.displayGuiScreen(null);
-	        if (this.mc.currentScreen == null)
-	            this.mc.setIngameFocus();
+			Minecraft.getInstance().displayGuiScreen(null);
+	        if (Minecraft.getInstance().currentScreen == null)
+	            Minecraft.getInstance().setIngameFocus();
 		}
 		if(button == this.no)
 		{
-			this.mc.displayGuiScreen(null);
-	        if (this.mc.currentScreen == null)
-	            this.mc.setIngameFocus();
+			Minecraft.getInstance().displayGuiScreen(null);
+	        if (Minecraft.getInstance().currentScreen == null)
+	            Minecraft.getInstance().setIngameFocus();
 		}
 	}
 	

--- a/src/main/java/org/millenaire/gui/GuiParchment.java
+++ b/src/main/java/org/millenaire/gui/GuiParchment.java
@@ -99,7 +99,7 @@ public class GuiParchment extends Screen
 	}
 	
 	@Override
-        protected void actionPerformed(Button button)
+        protected void onPress(Button button)
 	{
 	    if (button == this.forward) 
 	    {


### PR DESCRIPTION
## Summary
- rename legacy GUI lifecycle methods to their modern equivalents
- replace `mc` field accesses with `Minecraft.getInstance()`
- adjust button setup to use renderable widgets

## Testing
- `./gradlew --version` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_6883f13a4978833086313e82386f5fa1