### PR TITLE
Fix item registry usage

### DIFF
--- a/src/main/java/org/millenaire/capability/PlayerCropData.java
+++ b/src/main/java/org/millenaire/capability/PlayerCropData.java
@@ -5,6 +5,8 @@ import java.util.Map;
 
 import net.minecraft.item.Item;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.registries.ForgeRegistries;
 
 public class PlayerCropData implements IPlayerCropData {
     private Map<Item, Boolean> cropKnowledge = new HashMap<>();
@@ -23,7 +25,7 @@ public class PlayerCropData implements IPlayerCropData {
     public NBTTagCompound writeNBT() {
         NBTTagCompound tag = new NBTTagCompound();
         for (Item i : cropKnowledge.keySet()) {
-            tag.setBoolean(Item.itemRegistry.getNameForObject(i).toString(), cropKnowledge.get(i));
+            tag.setBoolean(ForgeRegistries.ITEMS.getKey(i).toString(), cropKnowledge.get(i));
         }
         return tag;
     }
@@ -32,7 +34,7 @@ public class PlayerCropData implements IPlayerCropData {
     public void readNBT(NBTTagCompound nbt) {
         cropKnowledge.clear();
         for (String key : nbt.getKeySet()) {
-            Item i = Item.getByNameOrId(key);
+            Item i = ForgeRegistries.ITEMS.getValue(new ResourceLocation(key));
             if (i != null) {
                 cropKnowledge.put(i, nbt.getBoolean(key));
             }

--- a/src/main/java/org/millenaire/util/ResourceLocationUtil.java
+++ b/src/main/java/org/millenaire/util/ResourceLocationUtil.java
@@ -2,6 +2,7 @@ package org.millenaire.util;
 
 import net.minecraft.item.Item;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.registries.ForgeRegistries;
 
 public class ResourceLocationUtil {
 
@@ -9,5 +10,5 @@ public class ResourceLocationUtil {
 	
 	public static String getString(ResourceLocation rl) { return rl.getResourceDomain() + ":" + rl.getResourcePath(); }
 	
-	public static Item getItem(ResourceLocation rl) { return Item.itemRegistry.getObject(rl); }
+        public static Item getItem(ResourceLocation rl) { return ForgeRegistries.ITEMS.getValue(rl); }
 }


### PR DESCRIPTION
## Summary
- access items via `ForgeRegistries.ITEMS` instead of the old `Item.itemRegistry`
- update player crop data NBT serialization to use `ForgeRegistries`

## Testing
- `gradle build` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_6883f42e4b38833080ce7b4d826672a1