### PR TITLE
Replace deprecated spawn & inventory methods

### DIFF
--- a/src/main/java/org/millenaire/CommonUtilities.java
+++ b/src/main/java/org/millenaire/CommonUtilities.java
@@ -58,16 +58,16 @@ public class CommonUtilities
 
                 argent.setCount(argent.getCount() % 64);
 
-                playerIn.getInventory().addItemStackToInventory(denier);
-                playerIn.getInventory().addItemStackToInventory(argent);
+                playerIn.getInventory().placeItemBackInInventory(denier);
+                playerIn.getInventory().placeItemBackInInventory(argent);
 
                 while(or.getCount() > 64)
                 {
-                        playerIn.getInventory().addItemStackToInventory(new ItemStack(MillItems.denierOr, 64, 0));
+                        playerIn.getInventory().placeItemBackInInventory(new ItemStack(MillItems.denierOr, 64, 0));
                         or.shrink(64);
                 }
 
-                playerIn.getInventory().addItemStackToInventory(or);
+                playerIn.getInventory().placeItemBackInInventory(or);
 	}
 	
 	/**

--- a/src/main/java/org/millenaire/entities/EntityMillVillager.java
+++ b/src/main/java/org/millenaire/entities/EntityMillVillager.java
@@ -216,7 +216,7 @@ public class EntityMillVillager extends PathfinderMob
                                 final EntityArrow arrow = new EntityArrow(this.level, this, (EntityLivingBase) entity, 1.6F, 12.0F);
 
                                 this.level.playSound(null, this.getPosition(), SoundEvents.ENTITY_ARROW_SHOOT, SoundCategory.PLAYERS, 1.0F, 1.0F / (this.getRNG().nextFloat() * 0.4F + 0.8F));
-                                this.level.spawnEntityInWorld(arrow);
+                                this.level.addFreshEntity(arrow);
 
 				attackTime = 60;
 

--- a/src/main/java/org/millenaire/items/ItemMillBow.java
+++ b/src/main/java/org/millenaire/items/ItemMillBow.java
@@ -102,10 +102,10 @@ public class ItemMillBow extends ItemBow
 			// extra arrow damage
 			entityArrow.setDamage(entityArrow.getDamage() + damageBonus);
 
-			if (!worldIn.isRemote) 
-			{
-				worldIn.spawnEntityInWorld(entityArrow);
-			}
+                        if (!worldIn.isRemote)
+                        {
+                                worldIn.addFreshEntity(entityArrow);
+                        }
 		}
 	}
 	

--- a/src/main/java/org/millenaire/items/ItemMillWallet.java
+++ b/src/main/java/org/millenaire/items/ItemMillWallet.java
@@ -131,19 +131,19 @@ public InteractionResultHolder<ItemStack> use(World worldIn, Player playerIn, In
 			if(nbt.hasKey("DenierOr") && nbt.getInteger("DenierOr") > 0)
 			{
 				ItemStack or = new ItemStack(MillItems.denierOr, nbt.getInteger("DenierOr"), 0);
-				playerIn.getInventory().addItemStackToInventory(or);
+                                playerIn.getInventory().placeItemBackInInventory(or);
 			}
 			
 			if(nbt.hasKey("DenierArgent") && nbt.getInteger("DenierArgent") > 0)
 			{
 				ItemStack argent = new ItemStack(MillItems.denierArgent, nbt.getInteger("DenierArgent"), 0);
-				playerIn.getInventory().addItemStackToInventory(argent);
+                                playerIn.getInventory().placeItemBackInInventory(argent);
 			}
 			
 			if(nbt.hasKey("Denier") && nbt.getInteger("Denier") > 0)
 			{
 				ItemStack denier = new ItemStack(MillItems.denier, nbt.getInteger("Denier"), 0);
-				playerIn.getInventory().addItemStackToInventory(denier);
+                                playerIn.getInventory().placeItemBackInInventory(denier);
 			}
 			
 			stack.setTagCompound(null);

--- a/src/main/java/org/millenaire/items/ItemMillWand.java
+++ b/src/main/java/org/millenaire/items/ItemMillWand.java
@@ -121,7 +121,7 @@ public class ItemMillWand extends Item
 //					System.out.println(entity.getVillagerType());
 //					entity.setChild();
 //					entity.setPosition(pos.getX(), pos.getY(), pos.getZ());
-//					worldIn.spawnEntityInWorld(entity);
+//					worldIn.addFreshEntity(entity);
 //				}
 //				stack.stackSize--;
 //				return true;
@@ -137,7 +137,7 @@ public class ItemMillWand extends Item
 //					entity = entity.setTypeAndGender(MillCulture.normanCulture.getVillagerType("normanLady"), 1);
 //					System.out.println(entity.getVillagerType());
 //					entity.setPosition(pos.getX(), pos.getY(), pos.getZ());
-//					worldIn.spawnEntityInWorld(entity);
+//					worldIn.addFreshEntity(entity);
 //				}
 //				stack.stackSize--;
 //				return true;

--- a/src/main/java/org/millenaire/village/Village.java
+++ b/src/main/java/org/millenaire/village/Village.java
@@ -65,7 +65,7 @@ public class Village {
                                 EntityMillVillager v = new EntityMillVillager(EntityMillVillager.MILL_VILLAGER.get(), world, 100100, culture);
 				v.setPosition(mainBlock.getX(), mainBlock.getY(), mainBlock.getZ());
 				v.setTypeAndGender(MillCulture.normanCulture.getVillagerType("normanKnight"), 1);
-				world.spawnEntityInWorld(v);
+                                world.addFreshEntity(v);
 				
 				BuildingLocation loc = p.findBuildingLocation(geo, new MillPathNavigate(v, world), mainBlock, 64, new Random(), p.buildingOrientation);
 				PlanIO.placeBuilding(p, loc, world);


### PR DESCRIPTION
## Summary
- use `addFreshEntity` instead of `spawnEntityInWorld`
- migrate inventory usage to `placeItemBackInInventory`

## Testing
- `gradle test` *(fails: Gradle 8.14.3 unsupported)*

------
https://chatgpt.com/codex/tasks/task_e_68846d71f2d8833098f85a69cc607c4d