### PR TITLE
Update to Gradle 7.6 and ForgeGradle 5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'net.minecraftforge.gradle:ForgeGradle:3.+'
+        classpath 'net.minecraftforge.gradle:ForgeGradle:5.1.77'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary
- upgrade the Gradle wrapper to version 7.6
- update ForgeGradle plugin to 5.1.77

## Testing
- `./gradlew tasks --no-daemon --console=plain` *(fails: Could not download dependencies from maven.minecraftforge.net)*

------
https://chatgpt.com/codex/tasks/task_e_6884827fb4c08330ab8febe8ebc3d411