### PR TITLE
Fix setup script for minimal systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,13 @@ Feel free to include the mod in your modpack! Although, we'd love it if you shar
 
 ### Redistributing
 Check out the LICENSE file.
+
+## Development setup
+To install the correct JDK and prefetch dependencies, run:
+
+```
+./scripts/setup.sh
+```
+
+The script also works around a bug in `ca-certificates-java` on minimal
+systems by creating a symlink at `/lib/security/cacerts` if it is missing.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -19,6 +19,12 @@ if [ "$need_jdk" = true ]; then
   echo "Installing OpenJDK ${JDK_VERSION}..."
   if command -v apt-get >/dev/null; then
     sudo apt-get update
+    # Work around ca-certificates-java bug on minimal systems.
+    # Some packages expect /lib/security/cacerts to exist.
+    if [ ! -e /lib/security/cacerts ]; then
+      sudo mkdir -p /lib/security
+      sudo ln -sf /etc/ssl/certs/java/cacerts /lib/security/cacerts
+    fi
     sudo apt-get install -y "openjdk-${JDK_VERSION}-jdk"
   else
     echo "Please install OpenJDK ${JDK_VERSION} manually." >&2


### PR DESCRIPTION
## Summary
- add workaround for missing `/lib/security/cacerts` when installing OpenJDK
- document development setup

## Testing
- `bash -n scripts/setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_6884a54a7e8483309c34374eb9adba72