### PR TITLE
Fix networking for Forge 1.14

### DIFF
--- a/src/main/java/org/millenaire/networking/MillNetwork.java
+++ b/src/main/java/org/millenaire/networking/MillNetwork.java
@@ -14,22 +14,24 @@ public class MillNetwork {
             PROTOCOL_VERSION::equals
     );
 
+    private static int id = 0;
+
+    private static int nextId() {
+        return id++;
+    }
+
     public static void init() {
-        int id = 0;
-        CHANNEL.messageBuilder(PacketSayTranslatedMessage.class, id++)
-                .encoder(PacketSayTranslatedMessage::encode)
-                .decoder(PacketSayTranslatedMessage::decode)
-                .consumer(PacketSayTranslatedMessage::handle)
-                .add();
-        CHANNEL.messageBuilder(PacketImportBuilding.class, id++)
-                .encoder(PacketImportBuilding::encode)
-                .decoder(PacketImportBuilding::decode)
-                .consumer(PacketImportBuilding::handle)
-                .add();
-        CHANNEL.messageBuilder(PacketExportBuilding.class, id++)
-                .encoder(PacketExportBuilding::encode)
-                .decoder(PacketExportBuilding::decode)
-                .consumer(PacketExportBuilding::handle)
-                .add();
+        CHANNEL.registerMessage(nextId(), PacketSayTranslatedMessage.class,
+                PacketSayTranslatedMessage::encode,
+                PacketSayTranslatedMessage::decode,
+                PacketSayTranslatedMessage::handle);
+        CHANNEL.registerMessage(nextId(), PacketImportBuilding.class,
+                PacketImportBuilding::encode,
+                PacketImportBuilding::decode,
+                PacketImportBuilding::handle);
+        CHANNEL.registerMessage(nextId(), PacketExportBuilding.class,
+                PacketExportBuilding::encode,
+                PacketExportBuilding::decode,
+                PacketExportBuilding::handle);
     }
 }

--- a/src/main/java/org/millenaire/networking/MillPacket.java
+++ b/src/main/java/org/millenaire/networking/MillPacket.java
@@ -4,17 +4,16 @@ import org.millenaire.blocks.BlockVillageStone;
 import org.millenaire.blocks.MillBlocks;
 import org.millenaire.items.MillItems;
 
-import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.PacketBuffer;
 import net.minecraftforge.network.NetworkEvent;
 import java.util.function.Supplier;
-import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.nbt.CompoundTag;
+import net.minecraft.entity.player.ServerPlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.core.BlockPos;
-import net.minecraft.world.level.Level;
+import net.minecraft.world.World;
 import net.minecraft.util.SoundCategory;
-import net.minecraft.init.SoundEvents;
-import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.SoundEvents;
 public class MillPacket
 {
         private int eventID;
@@ -29,26 +28,26 @@ public class MillPacket
 	
 	public int getID() { return eventID; }
 
-        public static void encode(MillPacket msg, FriendlyByteBuf buf) {
+        public static void encode(MillPacket msg, PacketBuffer buf) {
                 buf.writeInt(msg.eventID);
         }
 
-        public static MillPacket decode(FriendlyByteBuf buf) {
+        public static MillPacket decode(PacketBuffer buf) {
                 return new MillPacket(buf.readInt());
         }
 
         public static void handle(MillPacket message, Supplier<NetworkEvent.Context> ctx) {
                 ctx.get().enqueueWork(() -> {
-                        ServerPlayer sendingPlayer = ctx.get().getSender();
+                        ServerPlayerEntity sendingPlayer = ctx.get().getSender();
                         if (sendingPlayer != null) {
                                 if(message.getID() == 2) {
-                                        ItemStack heldItem = sendingPlayer.getMainHandItem();
+                                        ItemStack heldItem = sendingPlayer.getHeldItemMainhand();
                                         if(heldItem.getItem() == MillItems.wandNegation) {
-                                                Level world = sendingPlayer.level;
-                                                CompoundTag nbt = heldItem.getTag();
-                                                int posX = nbt.getInteger("X");
-                                                int posY = nbt.getInteger("Y");
-                                                int posZ = nbt.getInteger("Z");
+                                                World world = sendingPlayer.world;
+                                                CompoundNBT nbt = heldItem.getTag();
+                                                int posX = nbt.getInt("X");
+                                                int posY = nbt.getInt("Y");
+                                                int posZ = nbt.getInt("Z");
                                                 BlockVillageStone villStone = (BlockVillageStone)world.getBlockState(new BlockPos(posX, posY, posZ)).getBlock();
                                                 villStone.negate(world, new BlockPos(posX, posY, posZ), sendingPlayer);
                                         } else {
@@ -56,27 +55,27 @@ public class MillPacket
                                         }
                                 }
                                 if(message.getID() == 3) {
-                                        ItemStack heldItem = sendingPlayer.getMainHandItem();
+                                        ItemStack heldItem = sendingPlayer.getHeldItemMainhand();
                                         if(heldItem.getItem() == MillItems.wandNegation) {
-                                                Level world = sendingPlayer.level;
-                                                CompoundTag nbt = heldItem.getTag();
-                                                int id = nbt.getInteger("ID");
-                                                world.createExplosion(world.getEntityByID(id), world.getEntityByID(id).getX(), world.getEntityByID(id).getY(), world.getEntityByID(id).getZ(), 0.0F, false);
-                                                world.playSound(null, world.getEntityByID(id).getPosition(), SoundEvents.ENTITY_PLAYER_HURT, SoundCategory.PLAYERS, 1.0F, 0.4F);
-                                                world.removeEntity(world.getEntityByID(id));
+                                                World world = sendingPlayer.world;
+                                                CompoundNBT nbt = heldItem.getTag();
+                                                int id = nbt.getInt("ID");
+                                                world.createExplosion(world.getEntityById(id), world.getEntityById(id).getPosX(), world.getEntityById(id).getPosY(), world.getEntityById(id).getPosZ(), 0.0F, false);
+                                                world.playSound(null, world.getEntityById(id).getPosition(), SoundEvents.ENTITY_PLAYER_HURT, SoundCategory.PLAYERS, 1.0F, 0.4F);
+                                                world.removeEntity(world.getEntityById(id));
                                         } else {
                                                 System.err.println("Player not holding Wand of Negation when attempting to delete Villager");
                                         }
                                 }
                                 if(message.getID() == 4) {
-                                        ItemStack heldItem = sendingPlayer.getMainHandItem();
+                                        ItemStack heldItem = sendingPlayer.getHeldItemMainhand();
                                         if(heldItem.getItem() == MillItems.wandSummoning) {
-                                                Level world = sendingPlayer.level;
-                                                CompoundTag nbt = heldItem.getTag();
-                                                int posX = nbt.getInteger("X");
-                                                int posY = nbt.getInteger("Y");
-                                                int posZ = nbt.getInteger("Z");
-                                                world.setBlockState(new BlockPos(posX, posY, posZ), MillBlocks.villageStone.get().getDefaultState());
+                                                World world = sendingPlayer.world;
+                                                CompoundNBT nbt = heldItem.getTag();
+                                                int posX = nbt.getInt("X");
+                                                int posY = nbt.getInt("Y");
+                                                int posZ = nbt.getInt("Z");
+                                                world.setBlockState(new BlockPos(posX, posY, posZ), MillBlocks.villageStone.get().getDefaultState(), 3);
                                         } else {
                                                 System.err.println("Player not holding Wand of Summoning when attempting to create Village");
                                         }

--- a/src/main/java/org/millenaire/networking/PacketExportBuilding.java
+++ b/src/main/java/org/millenaire/networking/PacketExportBuilding.java
@@ -2,7 +2,7 @@ package org.millenaire.networking;
 
 import org.millenaire.building.PlanIO;
 
-import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.PacketBuffer;
 import net.minecraftforge.network.NetworkEvent;
 import java.util.function.Supplier;
 import net.minecraftforge.server.ServerLifecycleHooks;
@@ -17,11 +17,11 @@ public class PacketExportBuilding {
 	}
 	
 	public PacketExportBuilding(BlockPos startPos) { this.pos = startPos; }
-        public static void encode(PacketExportBuilding msg, FriendlyByteBuf buf) {
+        public static void encode(PacketExportBuilding msg, PacketBuffer buf) {
                 buf.writeBlockPos(msg.pos);
         }
 
-        public static PacketExportBuilding decode(FriendlyByteBuf buf) {
+        public static PacketExportBuilding decode(PacketBuffer buf) {
                 return new PacketExportBuilding(buf.readBlockPos());
         }
 

--- a/src/main/java/org/millenaire/networking/PacketImportBuilding.java
+++ b/src/main/java/org/millenaire/networking/PacketImportBuilding.java
@@ -2,7 +2,7 @@ package org.millenaire.networking;
 
 import org.millenaire.building.PlanIO;
 
-import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.PacketBuffer;
 import net.minecraftforge.network.NetworkEvent;
 import java.util.function.Supplier;
 import net.minecraftforge.server.ServerLifecycleHooks;
@@ -17,11 +17,11 @@ public class PacketImportBuilding {
 	}
 	
 	public PacketImportBuilding(BlockPos startPos) { this.pos = startPos; }
-        public static void encode(PacketImportBuilding msg, FriendlyByteBuf buf) {
+        public static void encode(PacketImportBuilding msg, PacketBuffer buf) {
                 buf.writeBlockPos(msg.pos);
         }
 
-        public static PacketImportBuilding decode(FriendlyByteBuf buf) {
+        public static PacketImportBuilding decode(PacketBuffer buf) {
                 return new PacketImportBuilding(buf.readBlockPos());
         }
 

--- a/src/main/java/org/millenaire/networking/PacketSayTranslatedMessage.java
+++ b/src/main/java/org/millenaire/networking/PacketSayTranslatedMessage.java
@@ -2,8 +2,8 @@ package org.millenaire.networking;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.language.I18n;
-import net.minecraft.network.chat.Component;
-import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.util.text.TranslationTextComponent;
+import net.minecraft.network.PacketBuffer;
 import net.minecraftforge.network.NetworkEvent;
 import java.util.function.Supplier;
 
@@ -18,16 +18,16 @@ public class PacketSayTranslatedMessage {
 	public PacketSayTranslatedMessage(String message) { this.message = message; }
 	
 
-        public static void encode(PacketSayTranslatedMessage msg, FriendlyByteBuf buf) {
+        public static void encode(PacketSayTranslatedMessage msg, PacketBuffer buf) {
                 buf.writeUtf(msg.message);
         }
 
-        public static PacketSayTranslatedMessage decode(FriendlyByteBuf buf) {
+        public static PacketSayTranslatedMessage decode(PacketBuffer buf) {
                 return new PacketSayTranslatedMessage(buf.readUtf());
         }
 
         public static void handle(PacketSayTranslatedMessage msg, Supplier<NetworkEvent.Context> ctx) {
-                ctx.get().enqueueWork(() -> Minecraft.getInstance().player.sendSystemMessage(Component.translatable(msg.message)));
+                ctx.get().enqueueWork(() -> Minecraft.getInstance().player.sendMessage(new TranslationTextComponent(msg.message), Minecraft.getInstance().player.getUniqueID()));
                 ctx.get().setPacketHandled(true);
         }
 	


### PR DESCRIPTION
## Summary
- update packet classes to use `PacketBuffer` and other 1.14 names
- replace removed world/entity calls
- register messages with `SimpleChannel`

## Testing
- `./gradlew test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6884c31e8c888330a426b9714cd3d095