### PR TITLE
Fix ResourceLocationUtil.getString

### DIFF
--- a/src/main/java/org/millenaire/util/ResourceLocationUtil.java
+++ b/src/main/java/org/millenaire/util/ResourceLocationUtil.java
@@ -8,7 +8,7 @@ public class ResourceLocationUtil {
 
 	public static ResourceLocation getRL(String rl) { return new ResourceLocation(rl); }
 	
-	public static String getString(ResourceLocation rl) { return rl.getResourceDomain() + ":" + rl.getResourcePath(); }
+        public static String getString(ResourceLocation rl) { return rl.getNamespace() + ":" + rl.getPath(); }
 	
         public static Item getItem(ResourceLocation rl) { return ForgeRegistries.ITEMS.getValue(rl); }
 }


### PR DESCRIPTION
## Summary
- use `ResourceLocation.getNamespace()` and `getPath()` in `getString`

## Testing
- `./gradlew test --no-daemon` *(fails: pattern matching in instanceof is not supported in -source 8)*

------
https://chatgpt.com/codex/tasks/task_e_6884f207aa508330a081406b5d22e8ae