### PR TITLE
Set Gradle to use Java 8

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-org.gradle.java.home=/root/.local/share/mise/installs/java/17.0.2
+org.gradle.java.home=/usr/lib/jvm/java-8-openjdk-amd64


### PR DESCRIPTION
## Summary
- point org.gradle.java.home to an OpenJDK 8 installation

## Testing
- `./gradlew build --no-daemon` *(fails: compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_6884f7a46bd48330a728fe747d6d5a86