### PR TITLE
Fix gradle JAVA_HOME setting

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
-org.gradle.java.home=/usr/lib/jvm/java-8-openjdk-amd64
+# Use the system Java installation rather than a hard coded path
+# org.gradle.java.home=/usr/lib/jvm/java-8-openjdk-amd64


### PR DESCRIPTION
## Summary
- comment invalid org.gradle.java.home value so the build uses the system JDK

The build still fails because the source code targets old MCP names that don't
exist in the 1.14.4 mappings. Porting the code to the new API and updating
imports will be needed to get a successful build.

## Testing
- `./gradlew clean`
- `./gradlew build` *(fails: cannot find symbol)*

------
https://chatgpt.com/codex/tasks/task_e_6884fc2069048330937901ffbab717b8