### PR TITLE
Switch build to FG3 for MC 1.14

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'net.minecraftforge.gradle:ForgeGradle:5.1.77'
+        classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '3.+', changing: true
     }
 }
 
@@ -14,7 +14,7 @@ apply plugin: "net.minecraftforge.gradle"
 sourceCompatibility = targetCompatibility = compileJava.sourceCompatibility = compileJava.targetCompatibility = '1.8'
 
 project.group = "org.millenaire.millenaire"
-project.version = "1.8.9-7.0.0-A2.3"
+project.version = "1.14.4-7.0.0"
 
 
 minecraft {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/org/millenaire/Millenaire.java
+++ b/src/main/java/org/millenaire/Millenaire.java
@@ -46,7 +46,7 @@ public class Millenaire
 {
 	public static final String MODID = "millenaire";
 	public static final String NAME = "Mill\u00e9naire";
-	public static final String VERSION = "7.0.0";
+        public static final String VERSION = "7.0.0-1.14.4";
 
 	public static boolean isServer = true;
 	

--- a/src/main/java/org/millenaire/Reference.java
+++ b/src/main/java/org/millenaire/Reference.java
@@ -3,6 +3,6 @@ package org.millenaire;
 public class Reference {
 	public static final String MOD_ID = "millenaire";
 	public static final String NAME = "Mill\u00e9naire";
-	public static final String VERSION = "7.0.0";
+        public static final String VERSION = "7.0.0-1.14.4";
 
 }


### PR DESCRIPTION
## Summary
- use ForgeGradle 3 plugin
- update gradle wrapper for FG3 (Gradle 4.9)
- target Java 8 in build script but rely on system JDK
- bump mod version constants to `7.0.0-1.14.4`
- restore previous wrapper JAR to avoid binary diff

## Testing
- ❌ `./gradlew tasks --all` *(failed: java.lang.ExceptionInInitializerError)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68850728998883309a3adb5166f444a8