### PR TITLE
Add Forge issue tracker URL

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -1,6 +1,7 @@
 modLoader="javafml"
 loaderVersion="[47,)"
 license="MIT"
+issueTrackerURL="https://github.com/Millenaire/Millenaire/issues"
 showAsResourcePack=false
 
 [[mods]]


### PR DESCRIPTION
## Summary
- add `issueTrackerURL` in `mods.toml`

## Testing
- `./gradlew --version`
- `./gradlew tasks --all` *(fails: Unable to start the daemon process)*

------
https://chatgpt.com/codex/tasks/task_e_68850b2a502c8330a4e79ad16b232c4a