### PR TITLE
Fix event handling for modern Forge

### DIFF
--- a/src/main/java/org/millenaire/Millenaire.java
+++ b/src/main/java/org/millenaire/Millenaire.java
@@ -17,6 +17,7 @@ import org.millenaire.items.ItemMillAmulet;
 import org.millenaire.networking.MillNetwork;
 import org.millenaire.capability.PlayerCropProvider;
 import org.millenaire.capability.CapabilityEvents;
+import org.millenaire.events.MillenaireEventHandler;
 
 import net.minecraft.block.Block;
 import net.minecraft.item.ItemGroup;
@@ -76,6 +77,7 @@ public class Millenaire
                 PlayerCropProvider.register();
                 new CapabilityEvents();
                 MinecraftForge.EVENT_BUS.register(new RaidEvent.RaidEventHandler());
+                MinecraftForge.EVENT_BUS.register(new MillenaireEventHandler());
 
                 setForbiddenBlocks();
 

--- a/src/main/java/org/millenaire/events/MillenaireEventHandler.java
+++ b/src/main/java/org/millenaire/events/MillenaireEventHandler.java
@@ -3,16 +3,16 @@ package org.millenaire.events;
 import org.millenaire.PlayerTracker;
 
 import net.minecraft.entity.player.Player;
-import net.minecraftforge.event.entity.EntityEvent.EntityConstructing;
-import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.event.entity.EntityJoinWorldEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 public class MillenaireEventHandler {
 
 	@SubscribeEvent
-	public void onEntityConstructing(EntityConstructing event) {
-		if (event.entity instanceof Player && PlayerTracker.get((Player) event.entity) == null)
-		{
-			PlayerTracker.register((Player) event.entity);
-		}
-	}
+        public void onEntityConstructing(EntityJoinWorldEvent event) {
+                if (event.getEntity() instanceof Player && PlayerTracker.get((Player) event.getEntity()) == null)
+                {
+                        PlayerTracker.register((Player) event.getEntity());
+                }
+        }
 }


### PR DESCRIPTION
## Summary
- update `MillenaireEventHandler` to use `EntityJoinWorldEvent`
- switch to `net.minecraftforge.eventbus.api.SubscribeEvent`
- register `MillenaireEventHandler` on the Forge event bus

## Testing
- `./gradlew build` *(fails: Unable to start the daemon process)*

------
https://chatgpt.com/codex/tasks/task_e_68850fcc8c848330bfff0640b7d6ec32