### PR TITLE
Update for modern side checks

### DIFF
--- a/src/main/java/org/millenaire/entities/EntityMillVillager.java
+++ b/src/main/java/org/millenaire/entities/EntityMillVillager.java
@@ -267,7 +267,7 @@ public class EntityMillVillager extends PathfinderMob
 							}
 						}
 
-                                                if (hadFullHealth && (player.getMainHandItem() == null || MillCommonUtilities.getItemWeaponDamage(player.getMainHandItem().getItem()) <= 1) && !level.isRemote) {
+                                                if (hadFullHealth && (player.getMainHandItem() == null || MillCommonUtilities.getItemWeaponDamage(player.getMainHandItem().getItem()) <= 1) && !level.isClientSide) {
 							ServerSender.sendTranslatedSentence(player, MLN.ORANGE, "ui.communicationexplanations");
 						}
 					}

--- a/src/main/java/org/millenaire/entities/TileEntityVillageStone.java
+++ b/src/main/java/org/millenaire/entities/TileEntityVillageStone.java
@@ -41,7 +41,7 @@ public class TileEntityVillageStone extends TileEntity
 	{
 		World world = this.getWorld();
 		BlockPos pos = this.getPos();
-		if(!world.isRemote) { //server only
+                if(!world.isClientSide) { //server only
 			if(world.getBlockState(pos).getBlock() instanceof BlockVillageStone)
 			{
 
@@ -69,14 +69,14 @@ public class TileEntityVillageStone extends TileEntity
 
 					if(MillConfig.villageAnnouncement)
 					{
-						if(!world.isRemote)
+                                                if(!world.isClientSide)
 						{
                                                         for(int i = 0; i < world.playerEntities.size(); i++)
                                                                 world.playerEntities.get(i).sendMessage(new TextComponent(culture + " village " + villageName + " discovered at " + pos.getX() + ", " + pos.getY() + ", " + pos.getZ()), world.playerEntities.get(i).getUUID());
 						}
 					}
 
-					if(!world.isRemote)
+                                        if(!world.isClientSide)
 						System.out.println(culture + " village " + villageName + " created at " + pos.getX() + ", " + pos.getY() + ", " + pos.getZ());
 					for(BuildingProject p : MillCulture.getCulture(culture).getVillageType(villageName).startingBuildings) {
 						BuildingType t = BuildingTypes.getTypeFromProject(p);

--- a/src/main/java/org/millenaire/generation/VillageGenerator.java
+++ b/src/main/java/org/millenaire/generation/VillageGenerator.java
@@ -29,9 +29,9 @@ public class VillageGenerator {
 		if(!MillConfig.generateVillages && !MillConfig.generateLoneBuildings || (world.getSpawnPoint().distanceSq(pos) < MillConfig.spawnDistance)) {
 			return false;
 		}
-		if(world.isRemote) {
-			return false;
-		}
+               if(world.isClientSide) {
+                       return false;
+               }
 		if(!VillageTracker.get(world).getNearVillages(pos, MillConfig.minVillageDistance).isEmpty()) {
 			return false;
 		}

--- a/src/main/java/org/millenaire/items/ItemMillAmulet.java
+++ b/src/main/java/org/millenaire/items/ItemMillAmulet.java
@@ -34,7 +34,7 @@ public class ItemMillAmulet extends Item
         public InteractionResultHolder<ItemStack> use(final World world, final Player entityplayer, InteractionHand hand)
         {
                 ItemStack itemstack = entityplayer.getItemInHand(hand);
-                if(this == MillItems.amuletSkollHati && !world.isRemote)
+                if(this == MillItems.amuletSkollHati && !world.isClientSide)
                 {
                         final long time = world.getWorldTime() + 24000L;
 

--- a/src/main/java/org/millenaire/items/ItemMillBow.java
+++ b/src/main/java/org/millenaire/items/ItemMillBow.java
@@ -102,7 +102,7 @@ public class ItemMillBow extends ItemBow
 			// extra arrow damage
 			entityArrow.setDamage(entityArrow.getDamage() + damageBonus);
 
-                        if (!worldIn.isRemote)
+                        if (!worldIn.isClientSide)
                         {
                                 worldIn.addFreshEntity(entityArrow);
                         }

--- a/src/main/java/org/millenaire/items/ItemMillParchment.java
+++ b/src/main/java/org/millenaire/items/ItemMillParchment.java
@@ -31,7 +31,7 @@ public class ItemMillParchment extends ItemWritableBook
         public InteractionResultHolder<ItemStack> use(Level worldIn, Player playerIn, InteractionHand hand)
     {
                 ItemStack itemStackIn = playerIn.getItemInHand(hand);
-                if(worldIn.isRemote)
+                if(worldIn.isClientSide)
                 {
                         MenuProvider provider = new SimpleMenuProvider((id, inv, player) -> new EmptyMenu(MillMenus.PARCHMENT_MENU.get(), id), new TextComponent("Parchment"));
                         NetworkHooks.openGui((ServerPlayer)playerIn, provider);

--- a/src/main/java/org/millenaire/items/ItemMillSeeds.java
+++ b/src/main/java/org/millenaire/items/ItemMillSeeds.java
@@ -24,7 +24,7 @@ public class ItemMillSeeds extends ItemSeeds
         public InteractionResult useOn(UseOnContext context) {
                 Player playerIn = context.getPlayer();
                 World worldIn = context.getLevel();
-                if(playerIn != null && !worldIn.isRemote && PlayerTracker.get(playerIn).canPlayerUseCrop(context.getItemInHand().getItem())) {
+                if(playerIn != null && !worldIn.isClientSide && PlayerTracker.get(playerIn).canPlayerUseCrop(context.getItemInHand().getItem())) {
                         return super.useOn(context);
                 }
                 return InteractionResult.FAIL;

--- a/src/main/java/org/millenaire/items/ItemMillSign.java
+++ b/src/main/java/org/millenaire/items/ItemMillSign.java
@@ -45,7 +45,7 @@ public class ItemMillSign extends Item
                         {
                                 return InteractionResult.FAIL;
                         }
-                        else if (worldIn.isRemote)
+                        else if (worldIn.isClientSide)
                         {
                                 return InteractionResult.SUCCESS;
                         }

--- a/src/main/java/org/millenaire/items/ItemMillWand.java
+++ b/src/main/java/org/millenaire/items/ItemMillWand.java
@@ -43,12 +43,12 @@ public class ItemMillWand extends Item
 	@Override
         public boolean onItemUseFirst(ItemStack stack, Player playerIn, World worldIn, BlockPos pos, Direction side, float hitX, float hitY, float hitZ)
 	{
-                if(worldIn.getBlockState(pos).getBlock() == Blocks.OAK_SIGN && worldIn.isRemote && this == MillItems.wandNegation) {
+                if(worldIn.getBlockState(pos).getBlock() == Blocks.OAK_SIGN && worldIn.isClientSide && this == MillItems.wandNegation) {
 			PacketExportBuilding packet = new PacketExportBuilding(pos);
                         Millenaire.channel.sendToServer(packet);
 			return true;
 		}
-                else if(worldIn.getBlockState(pos).getBlock() == Blocks.OAK_SIGN && worldIn.isRemote && this == MillItems.wandSummoning) {
+                else if(worldIn.getBlockState(pos).getBlock() == Blocks.OAK_SIGN && worldIn.isClientSide && this == MillItems.wandSummoning) {
 			PacketImportBuilding packet =  new PacketImportBuilding(pos);
                         Millenaire.channel.sendToServer(packet);
 			return true;
@@ -77,7 +77,7 @@ public class ItemMillWand extends Item
                                 nbt.putInt("Y", pos.getY());
                                 nbt.putInt("Z", pos.getZ());
 
-                                if(worldIn.isRemote)
+                                if(worldIn.isClientSide)
                                 {
                                         // TODO migrate GUI opening to new Menu API
                                 }
@@ -88,7 +88,7 @@ public class ItemMillWand extends Item
 		{
 			if(worldIn.getBlockState(pos).getBlock() == Blocks.gold_block)
 			{
-				if(!worldIn.isRemote)
+                                if(!worldIn.isClientSide)
 				{	
 					System.out.println("Gold Creation");
                                         Millenaire.channel.sendTo(new PacketSayTranslatedMessage("message.notimplemented"), (ServerPlayer)playerIn);
@@ -105,7 +105,7 @@ public class ItemMillWand extends Item
                                 nbt.putInt("Y", pos.getY());
                                 nbt.putInt("Z", pos.getZ());
 
-				if(!worldIn.isRemote)
+                                if(!worldIn.isClientSide)
 				{
                                         Millenaire.channel.sendTo(new PacketSayTranslatedMessage("message.notimplemented"), (ServerPlayer)playerIn);
 //					playerIn.openGui(Millenaire.instance, 4, worldIn, playerIn.getPosition().getX(), playerIn.getPosition().getY(), playerIn.getPosition().getZ());
@@ -160,7 +160,7 @@ public class ItemMillWand extends Item
 					hasCrop = PlayerTracker.get(playerIn).canPlayerUseCrop(((BlockMillCrops)worldIn.getBlockState(pos).getBlock()).getSeed());
 					System.out.println((worldIn.getBlockState(pos).getBlock()).getItem(worldIn, pos).toString());
 
-					if(worldIn.isRemote)
+                                        if(worldIn.isClientSide)
 					{
 						if(hasCrop)
 						{
@@ -182,7 +182,7 @@ public class ItemMillWand extends Item
 						succeeded = true;
 					}
 
-					if(worldIn.isRemote)
+                                        if(worldIn.isClientSide)
 					{
 						if(succeeded)
 						{
@@ -218,7 +218,7 @@ public class ItemMillWand extends Item
                     PlayerTracker.get(playerIn).setCanUseCrop(MillItems.turmeric, true);
                 }
 
-				if(worldIn.isRemote)
+                                if(worldIn.isClientSide)
 				{
                                         playerIn.sendSystemMessage(Component.literal(playerIn.getDisplayNameString() + " can now plant everything"));
 				}
@@ -228,7 +228,7 @@ public class ItemMillWand extends Item
                         {
                                 boolean isLocked = ((TileEntityMillChest)worldIn.getBlockEntity(pos)).setLock();
 
-				if(worldIn.isRemote)
+                                if(worldIn.isClientSide)
 				{
 					if(isLocked)
 					{
@@ -255,7 +255,7 @@ public class ItemMillWand extends Item
 			else
 			{
 				CommonUtilities.changeMoney(playerIn);
-				if(worldIn.isRemote)
+                                if(worldIn.isClientSide)
 				{
                     playerIn.sendSystemMessage(Component.literal("Fixing Denier in " + playerIn.getDisplayNameString() + "'s Inventory"));
                 }


### PR DESCRIPTION
## Summary
- modernize side detection by using `isClientSide`
- use same logic in items, entities, and generator

## Testing
- `./gradlew test --no-daemon` *(fails: java.lang.ExceptionInInitializerError)*

------
https://chatgpt.com/codex/tasks/task_e_688526d8029c8330a7e3b511f17e3f22