### PR TITLE
Implement basic menus

### DIFF
--- a/src/main/java/org/millenaire/blocks/BlockMillChest.java
+++ b/src/main/java/org/millenaire/blocks/BlockMillChest.java
@@ -19,7 +19,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraftforge.network.NetworkHooks;
 
-import org.millenaire.gui.EmptyMenu;
+import org.millenaire.gui.MillChestMenu;
 import org.millenaire.gui.MillMenus;
 import org.millenaire.blocks.MillBlocks;
 
@@ -42,7 +42,7 @@ public class BlockMillChest extends ChestBlock {
     public InteractionResult use(BlockState state, Level level, BlockPos pos, Player player, InteractionHand hand,
             BlockHitResult hit) {
         if (!level.isClientSide) {
-            MenuProvider provider = new SimpleMenuProvider((id, inv, p) -> new EmptyMenu(MillMenus.CHEST_MENU.get(), id),
+            MenuProvider provider = new SimpleMenuProvider((id, inv, p) -> new MillChestMenu(MillMenus.CHEST_MENU.get(), id),
                     new TextComponent("Mill Chest"));
             NetworkHooks.openGui((ServerPlayer) player, provider, pos);
         }

--- a/src/main/java/org/millenaire/entities/EntityMillVillager.java
+++ b/src/main/java/org/millenaire/entities/EntityMillVillager.java
@@ -43,6 +43,14 @@ import net.minecraftforge.fml.common.registry.EntityRegistry;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegistryObject;
+import net.minecraftforge.network.NetworkHooks;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.MenuProvider;
+import net.minecraft.world.SimpleMenuProvider;
+import net.minecraft.network.chat.TextComponent;
+import org.millenaire.gui.OptionsMenu;
+import org.millenaire.gui.ChiefMenu;
+import org.millenaire.gui.MillMenus;
 import net.minecraft.entity.EntityClassification;
 import net.minecraft.entity.EntityType;
 import net.minecraft.init.SoundEvents;
@@ -386,16 +394,22 @@ public class EntityMillVillager extends PathfinderMob
 		playerIn.addStat(MillAchievement.firstContact, 1);
 		if(type.hireCost > 0)
 		{
-			this.isPlayerInteracting = true;
-                        playerIn.openGui(Millenaire.instance, 5, playerIn.level, this.getPosition().getX(), this.getPosition().getY(), this.getPosition().getZ());
-			return true;
-		}
-		if(type.isChief)
-		{
-			this.isPlayerInteracting = true;
-                        playerIn.openGui(Millenaire.instance, 4, playerIn.level, this.getPosition().getX(), this.getPosition().getY(), this.getPosition().getZ());
-			return true;
-		}
+                        this.isPlayerInteracting = true;
+                        if(playerIn instanceof ServerPlayer) {
+                            MenuProvider provider = new SimpleMenuProvider((id, inv, p) -> new OptionsMenu(MillMenus.OPTIONS_MENU.get(), id), new TextComponent("Options"));
+                            NetworkHooks.openGui((ServerPlayer)playerIn, provider, this.blockPosition());
+                        }
+                        return true;
+                }
+                if(type.isChief)
+                {
+                        this.isPlayerInteracting = true;
+                        if(playerIn instanceof ServerPlayer) {
+                            MenuProvider provider = new SimpleMenuProvider((id, inv, p) -> new ChiefMenu(MillMenus.CHIEF_MENU.get(), id), new TextComponent("Chief"));
+                            NetworkHooks.openGui((ServerPlayer)playerIn, provider, this.blockPosition());
+                        }
+                        return true;
+                }
 		//for Sadhu and Alchemist maitrepenser achievement
 		//Display Quest GUI if appropriate
 		//Display Hire GUI if Appropriate

--- a/src/main/java/org/millenaire/gui/ChiefMenu.java
+++ b/src/main/java/org/millenaire/gui/ChiefMenu.java
@@ -1,0 +1,16 @@
+package org.millenaire.gui;
+
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.inventory.MenuType;
+
+public class ChiefMenu extends AbstractContainerMenu {
+    public ChiefMenu(MenuType<?> type, int id) {
+        super(type, id);
+    }
+
+    @Override
+    public boolean stillValid(Player player) {
+        return true;
+    }
+}

--- a/src/main/java/org/millenaire/gui/ChiefScreen.java
+++ b/src/main/java/org/millenaire/gui/ChiefScreen.java
@@ -4,9 +4,10 @@ import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.network.chat.Component;
 import net.minecraft.entity.player.Inventory;
 import com.mojang.blaze3d.vertex.PoseStack;
+import org.millenaire.gui.ChiefMenu;
 
-public class ChiefScreen extends AbstractContainerScreen<EmptyMenu> {
-    public ChiefScreen(EmptyMenu menu, Inventory inv, Component title) {
+public class ChiefScreen extends AbstractContainerScreen<ChiefMenu> {
+    public ChiefScreen(ChiefMenu menu, Inventory inv, Component title) {
         super(menu, inv, title);
     }
 

--- a/src/main/java/org/millenaire/gui/MillChestMenu.java
+++ b/src/main/java/org/millenaire/gui/MillChestMenu.java
@@ -1,0 +1,16 @@
+package org.millenaire.gui;
+
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.inventory.MenuType;
+
+public class MillChestMenu extends AbstractContainerMenu {
+    public MillChestMenu(MenuType<?> type, int id) {
+        super(type, id);
+    }
+
+    @Override
+    public boolean stillValid(Player player) {
+        return true;
+    }
+}

--- a/src/main/java/org/millenaire/gui/MillChestScreen.java
+++ b/src/main/java/org/millenaire/gui/MillChestScreen.java
@@ -4,9 +4,10 @@ import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.network.chat.Component;
 import net.minecraft.entity.player.Inventory;
 import com.mojang.blaze3d.vertex.PoseStack;
+import org.millenaire.gui.MillChestMenu;
 
-public class MillChestScreen extends AbstractContainerScreen<EmptyMenu> {
-    public MillChestScreen(EmptyMenu menu, Inventory inv, Component title) {
+public class MillChestScreen extends AbstractContainerScreen<MillChestMenu> {
+    public MillChestScreen(MillChestMenu menu, Inventory inv, Component title) {
         super(menu, inv, title);
     }
 

--- a/src/main/java/org/millenaire/gui/MillMenus.java
+++ b/src/main/java/org/millenaire/gui/MillMenus.java
@@ -7,17 +7,21 @@ import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegistryObject;
 
 import org.millenaire.Millenaire;
+import org.millenaire.gui.ChiefMenu;
+import org.millenaire.gui.MillChestMenu;
+import org.millenaire.gui.OptionsMenu;
+import org.millenaire.gui.ParchmentMenu;
 
 public class MillMenus {
     public static final DeferredRegister<MenuType<?>> MENUS =
             DeferredRegister.create(ForgeRegistries.MENU_TYPES, Millenaire.MODID);
 
-    public static final RegistryObject<MenuType<EmptyMenu>> PARCHMENT_MENU =
-            MENUS.register("parchment_menu", () -> IForgeMenuType.create((id, inv, buf) -> new EmptyMenu(PARCHMENT_MENU.get(), id)));
-    public static final RegistryObject<MenuType<EmptyMenu>> CHEST_MENU =
-            MENUS.register("mill_chest_menu", () -> IForgeMenuType.create((id, inv, buf) -> new EmptyMenu(CHEST_MENU.get(), id)));
-    public static final RegistryObject<MenuType<EmptyMenu>> OPTIONS_MENU =
-            MENUS.register("options_menu", () -> IForgeMenuType.create((id, inv, buf) -> new EmptyMenu(OPTIONS_MENU.get(), id)));
-    public static final RegistryObject<MenuType<EmptyMenu>> CHIEF_MENU =
-            MENUS.register("chief_menu", () -> IForgeMenuType.create((id, inv, buf) -> new EmptyMenu(CHIEF_MENU.get(), id)));
+    public static final RegistryObject<MenuType<ParchmentMenu>> PARCHMENT_MENU =
+            MENUS.register("parchment_menu", () -> IForgeMenuType.create((id, inv, buf) -> new ParchmentMenu(PARCHMENT_MENU.get(), id)));
+    public static final RegistryObject<MenuType<MillChestMenu>> CHEST_MENU =
+            MENUS.register("mill_chest_menu", () -> IForgeMenuType.create((id, inv, buf) -> new MillChestMenu(CHEST_MENU.get(), id)));
+    public static final RegistryObject<MenuType<OptionsMenu>> OPTIONS_MENU =
+            MENUS.register("options_menu", () -> IForgeMenuType.create((id, inv, buf) -> new OptionsMenu(OPTIONS_MENU.get(), id)));
+    public static final RegistryObject<MenuType<ChiefMenu>> CHIEF_MENU =
+            MENUS.register("chief_menu", () -> IForgeMenuType.create((id, inv, buf) -> new ChiefMenu(CHIEF_MENU.get(), id)));
 }

--- a/src/main/java/org/millenaire/gui/OptionsMenu.java
+++ b/src/main/java/org/millenaire/gui/OptionsMenu.java
@@ -1,0 +1,16 @@
+package org.millenaire.gui;
+
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.inventory.MenuType;
+
+public class OptionsMenu extends AbstractContainerMenu {
+    public OptionsMenu(MenuType<?> type, int id) {
+        super(type, id);
+    }
+
+    @Override
+    public boolean stillValid(Player player) {
+        return true;
+    }
+}

--- a/src/main/java/org/millenaire/gui/OptionsScreen.java
+++ b/src/main/java/org/millenaire/gui/OptionsScreen.java
@@ -4,9 +4,10 @@ import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.network.chat.Component;
 import net.minecraft.entity.player.Inventory;
 import com.mojang.blaze3d.vertex.PoseStack;
+import org.millenaire.gui.OptionsMenu;
 
-public class OptionsScreen extends AbstractContainerScreen<EmptyMenu> {
-    public OptionsScreen(EmptyMenu menu, Inventory inv, Component title) {
+public class OptionsScreen extends AbstractContainerScreen<OptionsMenu> {
+    public OptionsScreen(OptionsMenu menu, Inventory inv, Component title) {
         super(menu, inv, title);
     }
 

--- a/src/main/java/org/millenaire/gui/ParchmentMenu.java
+++ b/src/main/java/org/millenaire/gui/ParchmentMenu.java
@@ -1,0 +1,16 @@
+package org.millenaire.gui;
+
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.inventory.MenuType;
+
+public class ParchmentMenu extends AbstractContainerMenu {
+    public ParchmentMenu(MenuType<?> type, int id) {
+        super(type, id);
+    }
+
+    @Override
+    public boolean stillValid(Player player) {
+        return true;
+    }
+}

--- a/src/main/java/org/millenaire/gui/ParchmentScreen.java
+++ b/src/main/java/org/millenaire/gui/ParchmentScreen.java
@@ -4,10 +4,11 @@ import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.network.chat.Component;
 import net.minecraft.entity.player.Inventory;
 import net.minecraft.world.inventory.MenuType;
+import org.millenaire.gui.ParchmentMenu;
 import com.mojang.blaze3d.vertex.PoseStack;
 
-public class ParchmentScreen extends AbstractContainerScreen<EmptyMenu> {
-    public ParchmentScreen(EmptyMenu menu, Inventory inv, Component title) {
+public class ParchmentScreen extends AbstractContainerScreen<ParchmentMenu> {
+    public ParchmentScreen(ParchmentMenu menu, Inventory inv, Component title) {
         super(menu, inv, title);
     }
 

--- a/src/main/java/org/millenaire/items/ItemMillParchment.java
+++ b/src/main/java/org/millenaire/items/ItemMillParchment.java
@@ -13,7 +13,7 @@ import net.minecraft.network.chat.TextComponent;
 import net.minecraft.world.SimpleMenuProvider;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResultHolder;
-import org.millenaire.gui.EmptyMenu;
+import org.millenaire.gui.ParchmentMenu;
 import org.millenaire.gui.MillMenus;
 
 public class ItemMillParchment extends ItemWritableBook
@@ -31,9 +31,9 @@ public class ItemMillParchment extends ItemWritableBook
         public InteractionResultHolder<ItemStack> use(Level worldIn, Player playerIn, InteractionHand hand)
     {
                 ItemStack itemStackIn = playerIn.getItemInHand(hand);
-                if(worldIn.isClientSide)
+                if(!worldIn.isClientSide && playerIn instanceof ServerPlayer)
                 {
-                        MenuProvider provider = new SimpleMenuProvider((id, inv, player) -> new EmptyMenu(MillMenus.PARCHMENT_MENU.get(), id), new TextComponent("Parchment"));
+                        MenuProvider provider = new SimpleMenuProvider((id, inv, player) -> new ParchmentMenu(MillMenus.PARCHMENT_MENU.get(), id), new TextComponent("Parchment"));
                         NetworkHooks.openGui((ServerPlayer)playerIn, provider);
                 }
 

--- a/src/main/java/org/millenaire/items/ItemMillWand.java
+++ b/src/main/java/org/millenaire/items/ItemMillWand.java
@@ -29,10 +29,16 @@ import javax.annotation.Nullable;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.TextComponent;
 import net.minecraft.core.Direction;
 import net.minecraft.world.World;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.InteractionResult;
+import net.minecraft.world.MenuProvider;
+import net.minecraft.world.SimpleMenuProvider;
+import net.minecraftforge.network.NetworkHooks;
+import org.millenaire.gui.OptionsMenu;
+import org.millenaire.gui.MillMenus;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 
@@ -77,9 +83,10 @@ public class ItemMillWand extends Item
                                 nbt.putInt("Y", pos.getY());
                                 nbt.putInt("Z", pos.getZ());
 
-                                if(worldIn.isClientSide)
+                                if(!worldIn.isClientSide && playerIn instanceof ServerPlayer)
                                 {
-                                        // TODO migrate GUI opening to new Menu API
+                                        MenuProvider provider = new SimpleMenuProvider((id, inv, p) -> new OptionsMenu(MillMenus.OPTIONS_MENU.get(), id), new TextComponent("Options"));
+                                        NetworkHooks.openGui((ServerPlayer)playerIn, provider, pos);
                                 }
 			}
 		}
@@ -290,9 +297,10 @@ public class ItemMillWand extends Item
                         player.getMainHandItem().setTag(nbt);
                         nbt.putInt("ID", entity.getEntityId());
 
-                        if(player.level.isClientSide)
+                        if(!player.level.isClientSide && player instanceof ServerPlayer)
                         {
-                                // TODO migrate GUI opening to new Menu API
+                                MenuProvider provider = new SimpleMenuProvider((id, inv, p) -> new OptionsMenu(MillMenus.OPTIONS_MENU.get(), id), new TextComponent("Options"));
+                                NetworkHooks.openGui((ServerPlayer)player, provider, entity.blockPosition());
                         }
 		}
 		return false;


### PR DESCRIPTION
## Summary
- create simple menu containers for GUI screens
- register new `MenuType` objects
- open the new GUIs via `NetworkHooks`
- migrate screens to use the specific menu classes

## Testing
- `./gradlew build` *(fails: ExceptionInInitializerError)*

------
https://chatgpt.com/codex/tasks/task_e_68852934cf18833088e12dd6d728b905