### PR TITLE
Update to modern Level API

### DIFF
--- a/src/main/java/org/millenaire/CommonUtilities.java
+++ b/src/main/java/org/millenaire/CommonUtilities.java
@@ -7,8 +7,8 @@ import org.millenaire.items.MillItems;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
-import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.item.ItemStack;
 
 public class CommonUtilities 
@@ -19,13 +19,13 @@ public class CommonUtilities
 	 * pretty much orgainizes the player's money
 	 * @param playerIn The player to orgainize
 	 */
-       public static void changeMoney(PlayerEntity playerIn)
+       public static void changeMoney(Player playerIn)
        {
                ItemStack denier = new ItemStack(MillItems.denier, 0);
                ItemStack argent = new ItemStack(MillItems.denierArgent, 0);
                ItemStack or = new ItemStack(MillItems.denierOr, 0);
 		
-               PlayerInventory inv = playerIn.inventory;
+               Inventory inv = playerIn.inventory;
                for(int i = 0; i < inv.getContainerSize(); i++)
                {
                        ItemStack stack = inv.getItem(i);

--- a/src/main/java/org/millenaire/RaidTracker.java
+++ b/src/main/java/org/millenaire/RaidTracker.java
@@ -1,10 +1,10 @@
 package org.millenaire;
 
 import net.minecraft.nbt.CompoundNBT;
-import net.minecraft.world.World;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.saveddata.SavedData;
 import net.minecraft.world.level.storage.DimensionDataStorage;
-import net.minecraft.world.server.ServerWorld;
+import net.minecraft.server.level.ServerLevel;
 
 public class RaidTracker extends SavedData
 {
@@ -24,11 +24,11 @@ public class RaidTracker extends SavedData
                return nbt;
        }
 
-       public static RaidTracker get(World world)
+       public static RaidTracker get(Level world)
        {
-               if (world instanceof ServerWorld)
+               if (world instanceof ServerLevel)
                {
-                       DimensionDataStorage storage = ((ServerWorld)world).getDataStorage();
+                       DimensionDataStorage storage = ((ServerLevel)world).getDataStorage();
                        return storage.computeIfAbsent(RaidTracker::new, IDENTITY);
                }
                return new RaidTracker();

--- a/src/main/java/org/millenaire/VillageTracker.java
+++ b/src/main/java/org/millenaire/VillageTracker.java
@@ -11,10 +11,10 @@ import org.millenaire.village.Village;
 
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.core.BlockPos;
-import net.minecraft.world.World;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.saveddata.SavedData;
 import net.minecraft.world.level.storage.DimensionDataStorage;
-import net.minecraft.world.server.ServerWorld;
+import net.minecraft.server.level.ServerLevel;
 
 public class VillageTracker extends SavedData
 {
@@ -76,11 +76,11 @@ public class VillageTracker extends SavedData
 	
 	public void unregisterVillage(UUID id) { villages.remove(id); }
 	
-       public static VillageTracker get(World world)
+       public static VillageTracker get(Level world)
        {
-               if (world instanceof ServerWorld)
+               if (world instanceof ServerLevel)
                {
-                       DimensionDataStorage storage = ((ServerWorld)world).getDataStorage();
+                       DimensionDataStorage storage = ((ServerLevel)world).getDataStorage();
                        return storage.computeIfAbsent(() -> new VillageTracker(IDENTITY), IDENTITY);
                }
                return new VillageTracker(IDENTITY);

--- a/src/main/java/org/millenaire/blocks/BlockDecorativeUpdate.java
+++ b/src/main/java/org/millenaire/blocks/BlockDecorativeUpdate.java
@@ -6,7 +6,7 @@ import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.BlockState;
 import net.minecraft.core.BlockPos;
-import net.minecraft.world.World;
+import net.minecraft.world.level.Level;
 
 public class BlockDecorativeUpdate extends Block
 {
@@ -19,13 +19,13 @@ public class BlockDecorativeUpdate extends Block
 		this.setTickRandomly(true);
 	}
 
-	public void updateTick(World worldIn, BlockPos pos, BlockState state, Random rand)
+        public void updateTick(Level worldIn, BlockPos pos, BlockState state, Random rand)
     {
 		int i = rand.nextInt(3);
 
         if (i > 1)
         {
-                worldIn.setBlockState(pos, updateState);
+                worldIn.setBlock(pos, updateState, 3);
         }
     }
 }

--- a/src/main/java/org/millenaire/blocks/BlockMillCrops.java
+++ b/src/main/java/org/millenaire/blocks/BlockMillCrops.java
@@ -15,7 +15,7 @@ import net.minecraft.client.resources.model.ModelResourceLocation;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.Item;
 import net.minecraft.core.BlockPos;
-import net.minecraft.world.World;
+import net.minecraft.world.level.Level;
 import net.minecraftforge.common.IPlantable;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -36,7 +36,7 @@ public class BlockMillCrops extends BlockCrops
 	}
 	
 	@Override
-	public void updateTick(World worldIn, BlockPos pos, BlockState state, Random rand)
+        public void updateTick(Level worldIn, BlockPos pos, BlockState state, Random rand)
     {
         super.checkAndDropBlock(worldIn, pos, state);
 
@@ -52,14 +52,14 @@ public class BlockMillCrops extends BlockCrops
                 {
                 	if (rand.nextInt((int)(25.0F / f) + 1) == 0)
                 	{
-                                worldIn.setBlockState(pos, state.withProperty(AGE, i + 1), 2);
+                                worldIn.setBlock(pos, state.setValue(AGE, i + 1), 2);
                 	}
                 }
             }
         }
     }
 	
-	private float getLocalGrowthChance(Block blockIn, World worldIn, BlockPos pos)
+        private float getLocalGrowthChance(Block blockIn, Level worldIn, BlockPos pos)
 	{
 		BlockState groundIn = worldIn.getBlockState(pos.down());
 		if(groundIn.getBlock() != Blocks.farmland)

--- a/src/main/java/org/millenaire/building/BuildingBlock.java
+++ b/src/main/java/org/millenaire/building/BuildingBlock.java
@@ -64,7 +64,7 @@ public class BuildingBlock
        {
                if (specialBlock != BuildingBlock.PRESERVEGROUNDDEPTH && specialBlock != BuildingBlock.PRESERVEGROUNDSURFACE && specialBlock != BuildingBlock.CLEARTREE)
                {
-                    worldIn.setBlockState(position, blockState);
+                    worldIn.setBlock(position, blockState);
                     worldIn.playSound(null, position, blockState.getSoundType().getPlaceSound(), SoundSource.BLOCKS, 0.3F, 0.6F);
                }
 		
@@ -106,17 +106,17 @@ public class BuildingBlock
                                 }
 
 				assert targetblock != null;
-                                worldIn.setBlockState(position, targetblock.defaultBlockState());
+                                worldIn.setBlock(position, targetblock.defaultBlockState());
                                 worldIn.playSound(null, position, targetblock.getSoundType().getPlaceSound(), SoundSource.BLOCKS, 0.3F, 0.6F);
 			} 
                         else if (onGeneration && validGroundBlock == Blocks.DIRT && worldIn.isEmptyBlock(position.above()))
                         {
-                                worldIn.setBlockState(position, Blocks.GRASS_BLOCK.defaultBlockState());
+                                worldIn.setBlock(position, Blocks.GRASS_BLOCK.defaultBlockState());
                                 worldIn.playSound(null, position, Blocks.GRASS_BLOCK.getSoundType().getPlaceSound(), SoundSource.BLOCKS, 0.3F, 0.6F);
                         }
                         else if (validGroundBlock != block && !(validGroundBlock == Blocks.DIRT && block == Blocks.GRASS_BLOCK))
 			{
-                                worldIn.setBlockState(position, validGroundBlock.defaultBlockState());
+                                worldIn.setBlock(position, validGroundBlock.defaultBlockState());
                                 worldIn.playSound(null, position, validGroundBlock.getSoundType().getPlaceSound(), SoundSource.BLOCKS, 0.3F, 0.6F);
 			}
 		}
@@ -135,11 +135,11 @@ public class BuildingBlock
 
                                 if (onGeneration && targetBlock == Blocks.DIRT)
                                 {
-                                worldIn.setBlockState(position.down(), Blocks.GRASS_BLOCK.defaultBlockState());
+                                worldIn.setBlock(position.down(), Blocks.GRASS_BLOCK.defaultBlockState());
                                 }
 				else if (targetBlock != null) 
 				{
-                                worldIn.setBlockState(position.down(), targetBlock.defaultBlockState());
+                                worldIn.setBlock(position.down(), targetBlock.defaultBlockState());
 				}
 			}
 
@@ -157,11 +157,11 @@ public class BuildingBlock
 
                         if (onGeneration && targetBlock == Blocks.DIRT)
                         {
-                        worldIn.setBlockState(position.down(), Blocks.GRASS_BLOCK.defaultBlockState());
+                        worldIn.setBlock(position.down(), Blocks.GRASS_BLOCK.defaultBlockState());
                         }
 			else if (targetBlock != null) 
 			{
-                        worldIn.setBlockState(position.down(), targetBlock.defaultBlockState());
+                        worldIn.setBlock(position.down(), targetBlock.defaultBlockState());
 			}
 		}
                 else if (specialBlock == BuildingBlock.OAKSPAWN)
@@ -190,43 +190,43 @@ public class BuildingBlock
                 }
                 else if (specialBlock == BuildingBlock.SPAWNERSKELETON)
                 {
-                        worldIn.setBlockState(position, Blocks.SPAWNER.defaultBlockState());
+                        worldIn.setBlock(position, Blocks.SPAWNER.defaultBlockState());
                         final SpawnerBlockEntity tileentitymobspawner = (SpawnerBlockEntity) worldIn.getBlockEntity(position);
                         tileentitymobspawner.getSpawner().setEntityId(EntityType.SKELETON);
                 }
                 else if (specialBlock == BuildingBlock.SPAWNERZOMBIE)
                 {
-                        worldIn.setBlockState(position, Blocks.SPAWNER.defaultBlockState());
+                        worldIn.setBlock(position, Blocks.SPAWNER.defaultBlockState());
                         final SpawnerBlockEntity tileentitymobspawner = (SpawnerBlockEntity) worldIn.getBlockEntity(position);
                         tileentitymobspawner.getSpawner().setEntityId(EntityType.ZOMBIE);
                 }
                 else if (specialBlock == BuildingBlock.SPAWNERSPIDER)
                 {
-                        worldIn.setBlockState(position, Blocks.SPAWNER.defaultBlockState());
+                        worldIn.setBlock(position, Blocks.SPAWNER.defaultBlockState());
                         final SpawnerBlockEntity tileentitymobspawner = (SpawnerBlockEntity) worldIn.getBlockEntity(position);
                         tileentitymobspawner.getSpawner().setEntityId(EntityType.SPIDER);
                 }
                 else if (specialBlock == BuildingBlock.SPAWNERCAVESPIDER)
                 {
-                        worldIn.setBlockState(position, Blocks.SPAWNER.defaultBlockState());
+                        worldIn.setBlock(position, Blocks.SPAWNER.defaultBlockState());
                         final SpawnerBlockEntity tileentitymobspawner = (SpawnerBlockEntity) worldIn.getBlockEntity(position);
                         tileentitymobspawner.getSpawner().setEntityId(EntityType.CAVE_SPIDER);
                 }
                 else if (specialBlock == BuildingBlock.SPAWNERCREEPER)
                 {
-                        worldIn.setBlockState(position, Blocks.SPAWNER.defaultBlockState());
+                        worldIn.setBlock(position, Blocks.SPAWNER.defaultBlockState());
                         final SpawnerBlockEntity tileentitymobspawner = (SpawnerBlockEntity) worldIn.getBlockEntity(position);
                         tileentitymobspawner.getSpawner().setEntityId(EntityType.CREEPER);
                 }
                 else if (specialBlock == BuildingBlock.SPAWNERBLAZE)
                 {
-                        worldIn.setBlockState(position, Blocks.SPAWNER.defaultBlockState());
+                        worldIn.setBlock(position, Blocks.SPAWNER.defaultBlockState());
                         final SpawnerBlockEntity tileentitymobspawner = (SpawnerBlockEntity) worldIn.getBlockEntity(position);
                         tileentitymobspawner.getSpawner().setEntityId(EntityType.BLAZE);
                 }
                 else if (specialBlock == BuildingBlock.DISPENDERUNKNOWNPOWDER)
                 {
-                        worldIn.setBlockState(position, Blocks.DISPENSER.defaultBlockState());
+                        worldIn.setBlock(position, Blocks.DISPENSER.defaultBlockState());
                         final DispenserBlockEntity dispenser = (DispenserBlockEntity)worldIn.getBlockEntity(position);
                         dispenser.addItem(new ItemStack(MillItems.unknownPowder, 2));
                 }

--- a/src/main/java/org/millenaire/building/PlanIO.java
+++ b/src/main/java/org/millenaire/building/PlanIO.java
@@ -16,7 +16,7 @@ import org.millenaire.networking.PacketSayTranslatedMessage;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
-import net.minecraft.entity.player.Player;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.block.Blocks;
 import net.minecraft.world.item.Item;
@@ -31,7 +31,7 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.level.block.entity.SignBlockEntity;
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.EnumFacing;
-import net.minecraft.world.World;
+import net.minecraft.world.level.Level;
 import net.minecraftforge.common.util.Constants;
 
 public class PlanIO {
@@ -181,7 +181,7 @@ public class PlanIO {
 				return;
 			}
 
-                        World world = ServerLifecycleHooks.getCurrentServer().getEntityWorld();
+                        Level world = ServerLifecycleHooks.getCurrentServer().getLevel(Level.OVERWORLD);
 
 			File schem = getBuildingFile(name);
 			if(!schem.exists()) {
@@ -199,7 +199,7 @@ public class PlanIO {
 			for(int x = 0; x < plan.width; x++) {
 				for(int y = 0; y < plan.height; y++) {
 					for(int z = 0; z < plan.length; z++) {
-                                                world.setBlockState(new BlockPos(x + startPos.getX() + 1, y + startPos.getY() + plan.depth, z + startPos.getZ() + 1), blocks[y][z][x], 2);
+                                                world.setBlock(new BlockPos(x + startPos.getX() + 1, y + startPos.getY() + plan.depth, z + startPos.getZ() + 1), blocks[y][z][x], 2);
 					}
 				}
 			}
@@ -210,13 +210,13 @@ public class PlanIO {
 		}
 	}
 	
-	public static void placeBuilding(BuildingPlan plan, BuildingLocation loc, World world) {
+        public static void placeBuilding(BuildingPlan plan, BuildingLocation loc, Level world) {
 		BlockState[][][] blocks = plan.buildingArray;
 
 		for(int x = 0; x < plan.width; x++) {
 			for(int y = 0; y < plan.height; y++) {
 				for(int z = 0; z < plan.length; z++) {
-                                        world.setBlockState(new BlockPos(x + loc.position.getX(), y + loc.position.getY() + plan.depth, z + loc.position.getZ()), blocks[y][z][x], 2);
+                                        world.setBlock(new BlockPos(x + loc.position.getX(), y + loc.position.getY() + plan.depth, z + loc.position.getZ()), blocks[y][z][x], 2);
 				}
 			}
 		}

--- a/src/main/java/org/millenaire/entities/ai/EntityAIGateOpen.java
+++ b/src/main/java/org/millenaire/entities/ai/EntityAIGateOpen.java
@@ -10,7 +10,7 @@ import net.minecraft.pathfinding.PathEntity;
 import net.minecraft.pathfinding.PathNavigateGround;
 import net.minecraft.pathfinding.PathPoint;
 import net.minecraft.core.BlockPos;
-import net.minecraft.world.World;
+import net.minecraft.world.level.Level;
 
 public class EntityAIGateOpen extends Goal
 {
@@ -141,7 +141,7 @@ public class EntityAIGateOpen extends Goal
         return block instanceof BlockFenceGate && block.getMaterial() == Material.wood ? (BlockFenceGate)block : null;
     }
     
-    private void toggleGate(BlockFenceGate gateIn, World worldIn, BlockPos pos, boolean open)
+    private void toggleGate(BlockFenceGate gateIn, Level worldIn, BlockPos pos, boolean open)
     {
     	if(gateIn == null)
     	{
@@ -156,12 +156,12 @@ public class EntityAIGateOpen extends Goal
     	
     	if(open)
     	{
-            worldIn.setBlockState(pos, state.withProperty(BlockFenceGate.OPEN, true));
+            worldIn.setBlock(pos, state.setValue(BlockFenceGate.OPEN, true), 3);
         }
     	
     	if(!open)
     	{
-            worldIn.setBlockState(pos, state.withProperty(BlockFenceGate.OPEN, false));
+            worldIn.setBlock(pos, state.setValue(BlockFenceGate.OPEN, false), 3);
         }
     }
 }

--- a/src/main/java/org/millenaire/generation/VillageGenerator.java
+++ b/src/main/java/org/millenaire/generation/VillageGenerator.java
@@ -6,9 +6,9 @@ import org.millenaire.MillConfig;
 import org.millenaire.VillageTracker;
 import org.millenaire.blocks.MillBlocks;
 
-import net.minecraft.entity.player.Player;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.core.BlockPos;
-import net.minecraft.world.World;
+import net.minecraft.world.level.Level;
 import net.minecraftforge.event.world.BiomeLoadingEvent;
 
 // IWorldGenerator is deprecated on modern Forge versions; use biome loading events instead.
@@ -25,7 +25,7 @@ public class VillageGenerator {
 	/**
 	 * Attempt to generate the village
 	 */
-       private static boolean generateVillageAt(Random rand, BlockPos pos, World world) {
+       private static boolean generateVillageAt(Random rand, BlockPos pos, Level world) {
 		if(!MillConfig.generateVillages && !MillConfig.generateLoneBuildings || (world.getSpawnPoint().distanceSq(pos) < MillConfig.spawnDistance)) {
 			return false;
 		}
@@ -38,7 +38,7 @@ public class VillageGenerator {
 		else {
 			Player generatingPlayer = world.getClosestPlayer(pos.getX(), pos.getY(), pos.getZ(), -1);
                         if(rand.nextInt(50) == 1 && world.getChunkFromBlockCoords(pos).isLoaded()) {
-                                world.setBlockState(pos, MillBlocks.villageStone.get().getDefaultState());
+                                world.setBlock(pos, MillBlocks.villageStone.get().getDefaultState());
                         }
 			return false;
 		}

--- a/src/main/java/org/millenaire/items/ItemMillSeeds.java
+++ b/src/main/java/org/millenaire/items/ItemMillSeeds.java
@@ -3,12 +3,12 @@ package org.millenaire.items;
 import org.millenaire.PlayerTracker;
 
 import net.minecraft.block.Block;
-import net.minecraft.entity.player.Player;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemSeeds;
 import net.minecraft.item.ItemStack;
 import net.minecraft.core.BlockPos;
-import net.minecraft.world.World;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.InteractionResult;
 
@@ -23,7 +23,7 @@ public class ItemMillSeeds extends ItemSeeds
         @Override
         public InteractionResult useOn(UseOnContext context) {
                 Player playerIn = context.getPlayer();
-                World worldIn = context.getLevel();
+                Level worldIn = context.getLevel();
                 if(playerIn != null && !worldIn.isClientSide && PlayerTracker.get(playerIn).canPlayerUseCrop(context.getItemInHand().getItem())) {
                         return super.useOn(context);
                 }

--- a/src/main/java/org/millenaire/items/ItemMillSign.java
+++ b/src/main/java/org/millenaire/items/ItemMillSign.java
@@ -4,13 +4,13 @@ import org.millenaire.MillTabs;
 import org.millenaire.blocks.BlockMillSign;
 import org.millenaire.blocks.MillBlocks;
 
-import net.minecraft.entity.player.Player;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemStack;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.world.World;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.InteractionResult;
 
@@ -25,7 +25,7 @@ public class ItemMillSign extends Item
         {
                 ItemStack stack = context.getItemInHand();
                 Player playerIn = context.getPlayer();
-                World worldIn = context.getLevel();
+                Level worldIn = context.getLevel();
                 BlockPos pos = context.getClickedPos();
                 Direction side = context.getClickedFace();
 
@@ -51,7 +51,7 @@ public class ItemMillSign extends Item
                         }
                         else
                         {
-                                worldIn.setBlockState(pos, MillBlocks.blockMillSign.get().getDefaultState().withProperty(BlockMillSign.FACING, side), 3);
+                                worldIn.setBlock(pos, MillBlocks.blockMillSign.get().getDefaultState().setValue(BlockMillSign.FACING, side), 3);
 
                                 stack.shrink(1);
                                 BlockEntity tileentity = worldIn.getBlockEntity(pos);

--- a/src/main/java/org/millenaire/items/ItemMillWand.java
+++ b/src/main/java/org/millenaire/items/ItemMillWand.java
@@ -18,7 +18,7 @@ import org.millenaire.networking.PacketSayTranslatedMessage;
 import net.minecraft.block.properties.IProperty;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.entity.player.Player;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.Item;
@@ -31,7 +31,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TextComponent;
 import net.minecraft.core.Direction;
-import net.minecraft.world.World;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.MenuProvider;
@@ -47,7 +47,7 @@ public class ItemMillWand extends Item
 	ItemMillWand() { this.setMaxStackSize(1); }
 
 	@Override
-        public boolean onItemUseFirst(ItemStack stack, Player playerIn, World worldIn, BlockPos pos, Direction side, float hitX, float hitY, float hitZ)
+        public boolean onItemUseFirst(ItemStack stack, Player playerIn, Level worldIn, BlockPos pos, Direction side, float hitX, float hitY, float hitZ)
 	{
                 if(worldIn.getBlockState(pos).getBlock() == Blocks.OAK_SIGN && worldIn.isClientSide && this == MillItems.wandNegation) {
 			PacketExportBuilding packet = new PacketExportBuilding(pos);
@@ -67,7 +67,7 @@ public class ItemMillWand extends Item
         {
                 ItemStack stack = context.getItemInHand();
                 Player playerIn = context.getPlayer();
-                World worldIn = context.getLevel();
+                Level worldIn = context.getLevel();
                 BlockPos pos = context.getClickedPos();
                 Direction side = context.getClickedFace();
                 float hitX = (float)context.getClickLocation().x;
@@ -255,7 +255,7 @@ public class ItemMillWand extends Item
                 }
 				else
 				{
-                    worldIn.setBlockState(pos, worldIn.getBlockState(pos).cycleProperty(StoredPosition.VARIANT));
+                    worldIn.setBlock(pos, worldIn.getBlockState(pos).cycle(StoredPosition.VARIANT), 3);
                 }
 			}
 			//Fixes All Denier in your inventory (if no specific block/entity is clicked)
@@ -308,7 +308,7 @@ public class ItemMillWand extends Item
 
     @Override
     @OnlyIn(Dist.CLIENT)
-    public void appendHoverText(ItemStack stack, @Nullable World worldIn, List<ITextComponent> tooltip, ITooltipFlag flag)
+    public void appendHoverText(ItemStack stack, @Nullable Level worldIn, List<ITextComponent> tooltip, ITooltipFlag flag)
     {
             if(stack.getItem() == MillItems.wandCreative)
             {

--- a/src/main/java/org/millenaire/networking/MillPacket.java
+++ b/src/main/java/org/millenaire/networking/MillPacket.java
@@ -7,11 +7,12 @@ import org.millenaire.items.MillItems;
 import net.minecraft.network.PacketBuffer;
 import net.minecraftforge.network.NetworkEvent;
 import java.util.function.Supplier;
-import net.minecraft.entity.player.ServerPlayerEntity;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.core.BlockPos;
-import net.minecraft.world.World;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.Explosion;
 import net.minecraft.util.SoundCategory;
 import net.minecraft.util.SoundEvents;
 public class MillPacket
@@ -38,18 +39,18 @@ public class MillPacket
 
         public static void handle(MillPacket message, Supplier<NetworkEvent.Context> ctx) {
                 ctx.get().enqueueWork(() -> {
-                        ServerPlayerEntity sendingPlayer = ctx.get().getSender();
+                        ServerPlayer sendingPlayer = ctx.get().getSender();
                         if (sendingPlayer != null) {
                                 if(message.getID() == 2) {
                                         ItemStack heldItem = sendingPlayer.getHeldItemMainhand();
                                         if(heldItem.getItem() == MillItems.wandNegation) {
-                                                World world = sendingPlayer.world;
+                                                Level level = sendingPlayer.level;
                                                 CompoundNBT nbt = heldItem.getTag();
                                                 int posX = nbt.getInt("X");
                                                 int posY = nbt.getInt("Y");
                                                 int posZ = nbt.getInt("Z");
-                                                BlockVillageStone villStone = (BlockVillageStone)world.getBlockState(new BlockPos(posX, posY, posZ)).getBlock();
-                                                villStone.negate(world, new BlockPos(posX, posY, posZ), sendingPlayer);
+                                                BlockVillageStone villStone = (BlockVillageStone)level.getBlockState(new BlockPos(posX, posY, posZ)).getBlock();
+                                                villStone.negate(level, new BlockPos(posX, posY, posZ), sendingPlayer);
                                         } else {
                                                 System.err.println("Player not holding Wand of Negation when attempting to delete Village");
                                         }
@@ -57,12 +58,12 @@ public class MillPacket
                                 if(message.getID() == 3) {
                                         ItemStack heldItem = sendingPlayer.getHeldItemMainhand();
                                         if(heldItem.getItem() == MillItems.wandNegation) {
-                                                World world = sendingPlayer.world;
+                                                Level level = sendingPlayer.level;
                                                 CompoundNBT nbt = heldItem.getTag();
                                                 int id = nbt.getInt("ID");
-                                                world.createExplosion(world.getEntityById(id), world.getEntityById(id).getPosX(), world.getEntityById(id).getPosY(), world.getEntityById(id).getPosZ(), 0.0F, false);
-                                                world.playSound(null, world.getEntityById(id).getPosition(), SoundEvents.ENTITY_PLAYER_HURT, SoundCategory.PLAYERS, 1.0F, 0.4F);
-                                                world.removeEntity(world.getEntityById(id));
+                                                level.explode(level.getEntity(id), level.getEntity(id).getX(), level.getEntity(id).getY(), level.getEntity(id).getZ(), 0.0F, Explosion.BlockInteraction.NONE);
+                                                level.playSound(null, level.getEntity(id).blockPosition(), SoundEvents.ENTITY_PLAYER_HURT, SoundCategory.PLAYERS, 1.0F, 0.4F);
+                                                level.removeEntity(level.getEntity(id));
                                         } else {
                                                 System.err.println("Player not holding Wand of Negation when attempting to delete Villager");
                                         }
@@ -70,12 +71,12 @@ public class MillPacket
                                 if(message.getID() == 4) {
                                         ItemStack heldItem = sendingPlayer.getHeldItemMainhand();
                                         if(heldItem.getItem() == MillItems.wandSummoning) {
-                                                World world = sendingPlayer.world;
+                                                Level level = sendingPlayer.level;
                                                 CompoundNBT nbt = heldItem.getTag();
                                                 int posX = nbt.getInt("X");
                                                 int posY = nbt.getInt("Y");
                                                 int posZ = nbt.getInt("Z");
-                                                world.setBlockState(new BlockPos(posX, posY, posZ), MillBlocks.villageStone.get().getDefaultState(), 3);
+                                                level.setBlock(new BlockPos(posX, posY, posZ), MillBlocks.villageStone.get().getDefaultState(), 3);
                                         } else {
                                                 System.err.println("Player not holding Wand of Summoning when attempting to create Village");
                                         }


### PR DESCRIPTION
## Summary
- update player and world classes to `ServerPlayer`/`Level`
- replace deprecated `createExplosion` and `setBlockState` usages
- adjust several helper methods for new APIs

## Testing
- `./gradlew test --no-daemon --stacktrace` *(fails: java.lang.ExceptionInInitializerError)*

------
https://chatgpt.com/codex/tasks/task_e_68852f8074a483309fddf003f1a98ff2