### PR TITLE
Update world generation hooks

### DIFF
--- a/src/main/java/org/millenaire/VillageGeography.java
+++ b/src/main/java/org/millenaire/VillageGeography.java
@@ -245,18 +245,20 @@ public class VillageGeography
 		// We have to test not just for this chunk but the surrounding ones also
 		// as we need to do some operations that involve
 		// neighbouring blocks
-		for (int i = -1; i < 2; i++) 
-		{
-			for (int j = -1; j < 2; j++) 
-			{
-				if (!world.getChunkProvider().chunkExists((startX + mapStartX >> 4) + i, (startZ + mapStartZ >> 4) + j))
-				{
-					world.getChunkProvider().provideChunk((startX + mapStartX >> 4) + i, (startZ + mapStartZ >> 4) + j);
-				}
-			}
-		}
+                for (int i = -1; i < 2; i++)
+                {
+                        for (int j = -1; j < 2; j++)
+                        {
+                                int cx = (startX + mapStartX >> 4) + i;
+                                int cz = (startZ + mapStartZ >> 4) + j;
+                                if (!world.getChunkSource().hasChunk(cx, cz))
+                                {
+                                        world.getChunkSource().getChunk(cx, cz);
+                                }
+                        }
+                }
 
-		final Chunk chunk = world.getChunkFromBlockCoords(new BlockPos(startX + mapStartX, yBaseline ,startZ + mapStartZ));
+                final Chunk chunk = world.getChunk(new BlockPos(startX + mapStartX, yBaseline ,startZ + mapStartZ));
 
 		for (int i = 0; i < 16; i++) 
 		{

--- a/src/main/java/org/millenaire/generation/VillageGenerator.java
+++ b/src/main/java/org/millenaire/generation/VillageGenerator.java
@@ -10,16 +10,35 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.event.world.BiomeLoadingEvent;
+import net.minecraft.world.level.levelgen.GenerationStep;
+import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
+import net.minecraft.world.level.levelgen.feature.Feature;
+import net.minecraft.world.level.levelgen.feature.configurations.OreConfiguration;
+import net.minecraft.world.level.levelgen.placement.PlacedFeature;
+import net.minecraft.world.level.levelgen.placement.CountPlacement;
+import net.minecraft.world.level.levelgen.placement.InSquarePlacement;
+import net.minecraft.world.level.levelgen.placement.HeightRangePlacement;
+import net.minecraft.world.level.levelgen.VerticalAnchor;
 
 // IWorldGenerator is deprecated on modern Forge versions; use biome loading events instead.
 
 public class VillageGenerator {
 
+       private static final ConfiguredFeature<?, ?> GALIANITE_ORE_CONFIG =
+               Feature.ORE.configured(
+                       new OreConfiguration(OreConfiguration.Predicates.NATURAL_STONE,
+                               MillBlocks.galianiteOre.get().defaultBlockState(), 8));
+
+       private static final PlacedFeature GALIANITE_ORE = GALIANITE_ORE_CONFIG.placed(
+                       CountPlacement.of(20),
+                       InSquarePlacement.spread(),
+                       HeightRangePlacement.uniform(VerticalAnchor.bottom(), VerticalAnchor.absolute(64)));
+
        /**
         * Hook for modern Forge world generation. Called during {@link BiomeLoadingEvent}.
-        */
+       */
        public static void onBiomeLoading(BiomeLoadingEvent event) {
-               // TODO integrate generation logic with new biome loading system
+               event.getGeneration().addFeature(GenerationStep.Decoration.UNDERGROUND_ORES, GALIANITE_ORE);
        }
 	
 	/**
@@ -35,12 +54,12 @@ public class VillageGenerator {
 		if(!VillageTracker.get(world).getNearVillages(pos, MillConfig.minVillageDistance).isEmpty()) {
 			return false;
 		}
-		else {
-			Player generatingPlayer = world.getClosestPlayer(pos.getX(), pos.getY(), pos.getZ(), -1);
-                        if(rand.nextInt(50) == 1 && world.getChunkFromBlockCoords(pos).isLoaded()) {
-                                world.setBlock(pos, MillBlocks.villageStone.get().getDefaultState());
+                else {
+                        Player generatingPlayer = world.getClosestPlayer(pos.getX(), pos.getY(), pos.getZ(), -1);
+                        if(rand.nextInt(50) == 1) {
+                                world.setBlock(pos, MillBlocks.villageStone.get().defaultBlockState(), 3);
                         }
-			return false;
-		}
+                        return false;
+                }
 	}
 }


### PR DESCRIPTION
## Summary
- integrate ore generation using `BiomeLoadingEvent`
- use `ChunkGenerator` APIs instead of deprecated chunk methods

## Testing
- `./gradlew test` *(fails: Unable to start the daemon process)*

------
https://chatgpt.com/codex/tasks/task_e_68853175fef88330a6f06321f23190e0