### PR TITLE
Implement Raid info persistence

### DIFF
--- a/src/main/java/org/millenaire/RaidInfo.java
+++ b/src/main/java/org/millenaire/RaidInfo.java
@@ -1,0 +1,54 @@
+package org.millenaire;
+
+import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.core.BlockPos;
+
+/**
+ * Simple container for raid data used by {@link RaidTracker}.
+ */
+public class RaidInfo {
+    private BlockPos position;
+    private long startTime;
+    private boolean finished;
+
+    public RaidInfo() {}
+
+    public RaidInfo(BlockPos position, long startTime, boolean finished) {
+        this.position = position;
+        this.startTime = startTime;
+        this.finished = finished;
+    }
+
+    public BlockPos getPosition() {
+        return position;
+    }
+
+    public long getStartTime() {
+        return startTime;
+    }
+
+    public boolean isFinished() {
+        return finished;
+    }
+
+    public void setFinished(boolean finished) {
+        this.finished = finished;
+    }
+
+    public CompoundNBT toNBT() {
+        CompoundNBT tag = new CompoundNBT();
+        if(position != null) {
+            tag.putLong("Pos", position.toLong());
+        }
+        tag.putLong("start", startTime);
+        tag.putBoolean("finished", finished);
+        return tag;
+    }
+
+    public static RaidInfo fromNBT(CompoundNBT nbt) {
+        BlockPos pos = BlockPos.fromLong(nbt.getLong("Pos"));
+        long start = nbt.getLong("start");
+        boolean fin = nbt.getBoolean("finished");
+        return new RaidInfo(pos, start, fin);
+    }
+}

--- a/src/main/java/org/millenaire/RaidTracker.java
+++ b/src/main/java/org/millenaire/RaidTracker.java
@@ -1,5 +1,9 @@
 package org.millenaire;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.saveddata.SavedData;
@@ -8,19 +12,42 @@ import net.minecraft.server.level.ServerLevel;
 
 public class RaidTracker extends SavedData
 {
-	private final static String IDENTITY = "Millenaire.RaidInfo";
-	
-	private RaidTracker() { super(IDENTITY); }
+        private final static String IDENTITY = "Millenaire.RaidInfo";
+
+        private final Map<UUID, RaidInfo> raids = new HashMap<>();
+
+       private RaidTracker() { super(IDENTITY); }
+
+       public void registerRaid(UUID id, RaidInfo info) {
+               raids.put(id, info);
+               setDirty();
+       }
+
+       public void removeRaid(UUID id) {
+               raids.remove(id);
+               setDirty();
+       }
+
+       public Map<UUID, RaidInfo> getRaids() {
+               return raids;
+       }
 
        @Override
        public void load(CompoundNBT nbt)
        {
-
+               for(String key : nbt.getAllKeys()) {
+                       if(nbt.get(key) instanceof CompoundNBT) {
+                               raids.put(UUID.fromString(key), RaidInfo.fromNBT(nbt.getCompound(key)));
+                       }
+               }
        }
 
        @Override
        public CompoundNBT save(CompoundNBT nbt)
        {
+               for(Map.Entry<UUID, RaidInfo> e : raids.entrySet()) {
+                       nbt.put(e.getKey().toString(), e.getValue().toNBT());
+               }
                return nbt;
        }
 


### PR DESCRIPTION
## Summary
- add `RaidInfo` for simple raid metadata
- store raid info in `RaidTracker` and persist via `DimensionDataStorage`

## Testing
- `./gradlew build` *(fails: Unable to start the daemon process)*

------
https://chatgpt.com/codex/tasks/task_e_688532fd544c833080a141d534a2fc30