### PR TITLE
Specify JDK 8 for 1.14 setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,13 @@ Feel free to include the mod in your modpack! Although, we'd love it if you shar
 Check out the LICENSE file.
 
 ## Development setup
-To install the correct JDK and prefetch dependencies, run:
+This 1.14 version of Millénaire requires **Java 8**. To install the correct JDK
+and prefetch dependencies, run:
 
 ```
 ./scripts/setup.sh
 ```
 
-The script also works around a bug in `ca-certificates-java` on minimal
-systems by creating a symlink at `/lib/security/cacerts` if it is missing.
+The script installs OpenJDK 8 by default and works around a bug in
+`ca-certificates-java` on minimal systems by creating a symlink at
+`/lib/security/cacerts` if it is missing.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -5,8 +5,8 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 
 
-# Desired JDK version (default 17)
-JDK_VERSION="${JDK_VERSION:-17}"
+# Desired JDK version (default 8 for Minecraft 1.14)
+JDK_VERSION="${JDK_VERSION:-8}"
 
 need_jdk=false
 if ! type -p javac >/dev/null; then


### PR DESCRIPTION
## Summary
- use JDK 8 by default in setup.sh
- document that the 1.14 build requires Java 8

## Testing
- `./gradlew --no-daemon --console=plain help`

------
https://chatgpt.com/codex/tasks/task_e_688539cbf6348330a8b353224142e7c7