### PR TITLE
Implement server-only container creation

### DIFF
--- a/src/main/java/org/millenaire/entities/TileEntityMillChest.java
+++ b/src/main/java/org/millenaire/entities/TileEntityMillChest.java
@@ -2,6 +2,7 @@ package org.millenaire.entities;
 
 import net.minecraft.entity.player.Inventory;
 import net.minecraft.entity.player.Player;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.inventory.ChestMenu;
 import net.minecraft.world.MenuProvider;
@@ -85,6 +86,9 @@ public class TileEntityMillChest extends ChestBlockEntity implements MenuProvide
         @Override
         public AbstractContainerMenu createMenu(int id, Inventory playerInventory, Player player)
     {
-        return ChestMenu.threeRows(id, playerInventory, this);
+        if (player instanceof ServerPlayer) {
+            return ChestMenu.threeRows(id, playerInventory, this);
+        }
+        return null;
     }
 }


### PR DESCRIPTION
## Summary
- restrict chest menu creation to server side

## Testing
- `./gradlew --console=plain testClasses` *(fails: Could not resolve forge.jar)*

------
https://chatgpt.com/codex/tasks/task_e_68854c96cb1083308d2b855725c0bfd4