### PR TITLE
Update build to JDK16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/openjdk:8-jdk
+      - image: circleci/openjdk:16-jdk
       
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-  - oraclejdk8
+  - openjdk16
 
 os:
   - linux

--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ Feel free to include the mod in your modpack! Although, we'd love it if you shar
 Check out the LICENSE file.
 
 ## Development setup
-This 1.14 version of Millénaire requires **Java 8**. To install the correct JDK
+This 1.14 version of Millénaire requires **Java 16**. To install the correct JDK
 and prefetch dependencies, run:
 
 ```
 ./scripts/setup.sh
 ```
 
-The script installs OpenJDK 8 by default and works around a bug in
+The script installs OpenJDK 16 by default and works around a bug in
 `ca-certificates-java` on minimal systems by creating a symlink at
 `/lib/security/cacerts` if it is missing.

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 
 apply plugin: "net.minecraftforge.gradle"
 
-sourceCompatibility = targetCompatibility = compileJava.sourceCompatibility = compileJava.targetCompatibility = '1.8'
+sourceCompatibility = targetCompatibility = compileJava.sourceCompatibility = compileJava.targetCompatibility = '16'
 
 project.group = "org.millenaire.millenaire"
 project.version = "1.14.4-7.0.0"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 # Use the system Java installation rather than a hard coded path
-org.gradle.java.home=/opt/jdk8
+org.gradle.java.home=/opt/jdk16

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -5,8 +5,8 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 
 
-# Desired JDK version (default 8 for Minecraft 1.14)
-JDK_VERSION="${JDK_VERSION:-8}"
+# Desired JDK version (default 16 for Minecraft 1.14)
+JDK_VERSION="${JDK_VERSION:-16}"
 
 need_jdk=false
 if ! type -p javac >/dev/null; then


### PR DESCRIPTION
## Summary
- update README and setup docs for JDK 16
- default to JDK 16 in setup script and Gradle config
- use JDK 16 for CI builds

## Testing
- `./gradlew --version`
- ❌ `./gradlew test` *(failed: Unable to start the daemon process)*

------
https://chatgpt.com/codex/tasks/task_e_6885dcb0068083309d114243ba23f6de